### PR TITLE
fix ledger-transport-hid compilation on non-linux platforms

### DIFF
--- a/ledger-transport-hid/src/errors.rs
+++ b/ledger-transport-hid/src/errors.rs
@@ -25,7 +25,7 @@ pub enum LedgerHIDError {
     Comm(&'static str),
     /// Ioctl error
     #[error("Ledger device: Ioctl error")]
-    Ioctl(#[from] nix::Error),
+    Ioctl(#[from] crate::nix::Error),
     /// i/o error
     #[error("Ledger device: i/o error")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
using the `crate::` prefix in the error, so that the mock
module path works