### PR TITLE
Dont modify the source dir during code generation from proto file

### DIFF
--- a/ledger-transport-zemu/Cargo.toml
+++ b/ledger-transport-zemu/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ledger-transport-zemu"
-description = "Ledger Zemu Wallet - Zemu Transport"
+description = "Ledger Hardware Wallet - Zemu Transport"
 version = "0.7.0"
 license = "Apache-2.0"
 authors = ["Linfeng Yuan <linfeng@crypto.com>"]
 homepage = "https://github.com/zondax/ledger-rs"
 repository = "https://github.com/zondax/ledger-rs"
 readme = "README.md"
-categories  = ["authentication", "cryptography", "zemu"]
+categories  = ["authentication", "cryptography"]
 keywords = ["ledger", "nano", "blue", "apdu", "zemu"]
 edition = "2018"
 autobenches = false

--- a/ledger-transport-zemu/Cargo.toml
+++ b/ledger-transport-zemu/Cargo.toml
@@ -31,4 +31,5 @@ ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
 
 [build-dependencies]
 protoc-rust-grpc = "0.8.1"
+glob = "0.3.0"
 

--- a/ledger-transport-zemu/build.rs
+++ b/ledger-transport-zemu/build.rs
@@ -1,10 +1,36 @@
+use std::{env, fs, path::PathBuf};
+
 use protoc_rust_grpc::Codegen;
 
+fn out_dir() -> PathBuf {
+    PathBuf::from(env::var_os("OUT_DIR").unwrap())
+}
+
+fn generate_mod_rs() {
+    let out_dir = out_dir();
+
+    let mods = glob::glob(&out_dir.join("*.rs").to_string_lossy())
+        .expect("glob")
+        .filter_map(|p| {
+            p.ok()
+                .map(|p| format!("pub mod {};", p.file_stem().unwrap().to_string_lossy()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mod_rs = out_dir.join("proto_mod.rs");
+    fs::write(&mod_rs, format!("// @generated\n{}\n", mods)).expect("write");
+
+    println!("cargo:rustc-env=PROTO_MOD_RS={}", mod_rs.to_string_lossy());
+}
+
 fn main() {
+    let out = out_dir();
     Codegen::new()
-        .out_dir("src")
+        .out_dir(out)
         .input("zemu.proto")
         .rust_protobuf(true)
         .run()
         .expect("protoc-rust-grpc");
+    generate_mod_rs();
 }

--- a/ledger-transport-zemu/src/lib.rs
+++ b/ledger-transport-zemu/src/lib.rs
@@ -1,8 +1,6 @@
 mod errors;
-#[rustfmt::skip]
-mod zemu;
-#[rustfmt::skip]
-mod zemu_grpc;
+
+include!(env!("PROTO_MOD_RS"));
 
 use grpc::prelude::*;
 use grpc::ClientConf;


### PR DESCRIPTION
It is not recommended to modify the source dir according to [docs:](https://doc.rust-lang.org/cargo/reference/build-script-examples.html) 
`In general, build scripts should not modify any files outside of OUT_DIR. It may seem fine on the first blush, but it does cause problems when you use such crate as a dependency because there's an implicit invariant that sources in .cargo/registry should be immutable. cargo won't allow such scripts when packaging.`

Also, this causes a problem with the cargo-publish command  [that checks if the source dir was modified during the build process](https://github.com/rust-lang/cargo/issues/5073).

The solution here was taken from  [here](https://github.com/stepancheg/rust-protobuf/issues/324#issuecomment-476109276) as a solution for other issues that don't allow using include! or path macros directly.