### PR TITLE
TCP Transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "ledger-apdu",
     "ledger-transport",
     "ledger-transport-hid",
+    "ledger-transport-tcp",
     "ledger-transport-zemu",
     "ledger-zondax-generic"
 ]

--- a/ledger-transport-hid/Cargo.toml
+++ b/ledger-transport-hid/Cargo.toml
@@ -19,14 +19,14 @@ circle-ci = { repository = "zondax/ledger-rs" }
 name = "ledger"
 
 [dependencies]
-byteorder = "1.3.4"
-libc = "0.2.72"
-thiserror = "1.0.20"
-cfg-if = "0.1.10"
-lazy_static = "1.4.0"
-hex = "0.4.2"
+byteorder = "1.3"
+libc = "0.2"
+thiserror = "1.0"
+cfg-if = "0.1"
+lazy_static = "1.4"
+hex = "0.4"
 ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
-log = "0.4.8"
+log = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23.0"

--- a/ledger-transport-hid/src/lib.rs
+++ b/ledger-transport-hid/src/lib.rs
@@ -21,7 +21,7 @@ extern crate serial_test;
 
 mod errors;
 
-use crate::errors::LedgerHIDError;
+pub use crate::errors::LedgerHIDError;
 use byteorder::{BigEndian, ReadBytesExt};
 use cfg_if::cfg_if;
 use hidapi::HidDevice;

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -19,15 +19,11 @@ circle-ci = { repository = "zondax/ledger-rs" }
 name = "ledger_tcp"
 
 [dependencies]
-byteorder = "1.3.4"
-libc = "0.2.72"
-thiserror = "1.0.20"
-cfg-if = "0.1.10"
-lazy_static = "1.4.0"
-hex = "0.4.2"
+byteorder = "1.3"
+thiserror = "1.0"
 ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
-log = "0.4.8"
-tokio = {version = "1.2", features = ["full"]}
+log = "0.4"
+tokio = {version = "1", features = ["full"]}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.17.0"

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "ledger-transport-tcp"
+description = "Ledger Hardware Wallet - TCP Transport"
+version = "0.7.0"
+license = "Apache-2.0"
+authors = ["Louis Thiery <thiery.louis@gmail.com>"]
+homepage = "https://github.com/zondax/ledger-rs"
+repository = "https://github.com/zondax/ledger-rs"
+readme = "README.md"
+categories  = ["authentication", "cryptography"]
+keywords = ["ledger", "nano", "blue", "apdu"]
+edition = "2018"
+autobenches = false
+
+[badges]
+circle-ci = { repository = "zondax/ledger-rs" }
+
+[lib]
+name = "ledger_tcp"
+
+[dependencies]
+byteorder = "1.3.4"
+libc = "0.2.72"
+thiserror = "1.0.20"
+cfg-if = "0.1.10"
+lazy_static = "1.4.0"
+hex = "0.4.2"
+ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
+log = "0.4.8"
+tokio = {version = "1.2", features = ["full"]}
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = "0.17.0"
+
+[dependencies.hidapi]
+version = "1.2.3"
+default-features = false
+features=["linux-static-hidraw"]
+
+[dev-dependencies]
+serial_test = "0.4.0"
+env_logger = "0.7.1"

--- a/ledger-transport-tcp/README.md
+++ b/ledger-transport-tcp/README.md
@@ -1,0 +1,7 @@
+# ledger-transport-hid
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+Ledger APDU transport - TCP backend
+
+This works with the [speculos](https://github.com/LedgerHQ/speculos) emulator.

--- a/ledger-transport-tcp/src/errors.rs
+++ b/ledger-transport-tcp/src/errors.rs
@@ -16,7 +16,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum LedgerTcpError {
+pub enum TransportTcpError {
     /// Connection refused error
     #[error("TCP Connection Refused")]
     ConnectionRefused,
@@ -28,15 +28,15 @@ pub enum LedgerTcpError {
     ReadWouldBlock,
 }
 
-impl LedgerTcpError {
-    pub(crate) fn connection_refused() -> LedgerTcpError {
-        LedgerTcpError::ConnectionRefused
+impl TransportTcpError {
+    pub(crate) fn connection_refused() -> TransportTcpError {
+        TransportTcpError::ConnectionRefused
     }
-    pub(crate) fn connection_closed() -> LedgerTcpError {
-        LedgerTcpError::ConnectionClosed
+    pub(crate) fn connection_closed() -> TransportTcpError {
+        TransportTcpError::ConnectionClosed
     }
-    pub(crate) fn read_would_block() -> LedgerTcpError {
-        LedgerTcpError::ReadWouldBlock
+    pub(crate) fn read_would_block() -> TransportTcpError {
+        TransportTcpError::ReadWouldBlock
     }
 
 }

--- a/ledger-transport-tcp/src/errors.rs
+++ b/ledger-transport-tcp/src/errors.rs
@@ -1,0 +1,42 @@
+/*******************************************************************************
+*   (c) 2020 Helium Systems, Inc
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LedgerTcpError {
+    /// Connection refused error
+    #[error("TCP Connection Refused")]
+    ConnectionRefused,
+    #[error("TCP io error")]
+    Io(#[from] std::io::Error),
+    #[error("TCP Connection Closed")]
+    ConnectionClosed,
+    #[error("TCP Read Would Block")]
+    ReadWouldBlock,
+}
+
+impl LedgerTcpError {
+    pub(crate) fn connection_refused() -> LedgerTcpError {
+        LedgerTcpError::ConnectionRefused
+    }
+    pub(crate) fn connection_closed() -> LedgerTcpError {
+        LedgerTcpError::ConnectionClosed
+    }
+    pub(crate) fn read_would_block() -> LedgerTcpError {
+        LedgerTcpError::ReadWouldBlock
+    }
+
+}

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -21,37 +21,28 @@ extern crate serial_test;
 
 mod errors;
 use byteorder::{BigEndian as BE, WriteBytesExt};
-pub use errors::LedgerTcpError;
+pub use errors::TransportTcpError;
 use ledger_apdu::{APDUAnswer, APDUCommand};
 use std::result::Result;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use lazy_static::lazy_static;
-
-use std::sync::{Mutex, Arc};
-
-lazy_static! {
-    static ref STREAM: Arc<Mutex<Option<TcpStream>>> =
-        Arc::new(Mutex::new(None));
-}
-
 
 pub struct TransportTcp {}
 
 impl TransportTcp {
-    pub async fn new() -> Result<Self, errors::LedgerTcpError> {
+    pub async fn new() -> Result<Self, errors::TransportTcpError> {
         // test the connection but don't bother storing it
         TcpStream::connect("127.0.0.1:9999")
             .await
-            .map_err(|_| LedgerTcpError::connection_refused())?;
+            .map_err(|_| TransportTcpError::connection_refused())?;
 
 
         Ok(TransportTcp {})
     }
-    pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, LedgerTcpError> {
+    pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportTcpError> {
         let mut stream =         TcpStream::connect("127.0.0.1:9999")
             .await
-            .map_err(|_| LedgerTcpError::connection_refused())?;
+            .map_err(|_| TransportTcpError::connection_refused())?;
         let payload = command.serialize();
 
         let command_length = payload.len() as usize;
@@ -68,7 +59,7 @@ impl TransportTcp {
         // if the readiness event is a false positive.
         match stream.try_read(&mut buf) {
 
-            Ok(0) => Err(LedgerTcpError::connection_closed()),
+            Ok(0) => Err(TransportTcpError::connection_closed()),
             Ok(n) => {
                 let _packet_len = u32::from_be_bytes([buf[0],buf[1],buf[2],buf[3]]) as usize;
                 let apdu_frame = buf[4..n].to_vec();
@@ -76,7 +67,7 @@ impl TransportTcp {
                 Ok(APDUAnswer::from_answer(apdu_frame))
             },
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                Err(LedgerTcpError::read_would_block())
+                Err(TransportTcpError::read_would_block())
             }
             Err(e) => Err(e.into()),
         }

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -1,0 +1,84 @@
+/*******************************************************************************
+*   (c) 2020 Helium Systems, Inc
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+extern crate hidapi;
+#[cfg(test)]
+#[macro_use]
+extern crate serial_test;
+
+mod errors;
+use byteorder::{BigEndian as BE, WriteBytesExt};
+pub use errors::LedgerTcpError;
+use ledger_apdu::{APDUAnswer, APDUCommand};
+use std::result::Result;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use lazy_static::lazy_static;
+
+use std::sync::{Mutex, Arc};
+
+lazy_static! {
+    static ref STREAM: Arc<Mutex<Option<TcpStream>>> =
+        Arc::new(Mutex::new(None));
+}
+
+
+pub struct TransportTcp {}
+
+impl TransportTcp {
+    pub async fn new() -> Result<Self, errors::LedgerTcpError> {
+        // test the connection but don't bother storing it
+        TcpStream::connect("127.0.0.1:9999")
+            .await
+            .map_err(|_| LedgerTcpError::connection_refused())?;
+
+
+        Ok(TransportTcp {})
+    }
+    pub async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, LedgerTcpError> {
+        let mut stream =         TcpStream::connect("127.0.0.1:9999")
+            .await
+            .map_err(|_| LedgerTcpError::connection_refused())?;
+        let payload = command.serialize();
+
+        let command_length = payload.len() as usize;
+        let mut data = Vec::with_capacity(command_length + 4);
+        WriteBytesExt::write_u32::<BE>(&mut data, command_length as u32)?;
+        data.extend_from_slice(payload.as_slice());
+
+        stream.write_all(&data).await?;
+        // Wait for the socket to be readable
+        stream.readable().await?;
+
+        let mut buf: [u8; 256] = [0; 256];
+        // Try to read data, this may still fail with `WouldBlock`
+        // if the readiness event is a false positive.
+        match stream.try_read(&mut buf) {
+
+            Ok(0) => Err(LedgerTcpError::connection_closed()),
+            Ok(n) => {
+                let _packet_len = u32::from_be_bytes([buf[0],buf[1],buf[2],buf[3]]) as usize;
+                let apdu_frame = buf[4..n].to_vec();
+
+                Ok(APDUAnswer::from_answer(apdu_frame))
+            },
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(LedgerTcpError::read_would_block())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/ledger-transport-zemu/Cargo.toml
+++ b/ledger-transport-zemu/Cargo.toml
@@ -19,13 +19,13 @@ circle-ci = { repository = "zondax/ledger-rs" }
 name = "ledger_zemu"
 
 [dependencies]
-thiserror = "1.0.20"
-log = "0.4.11"
+thiserror = "1.0"
+log = "0.4"
 protobuf = "2"
-grpc = "0.8.1"
-grpc-protobuf = "0.8.1"
+grpc = "0.8"
+grpc-protobuf = "0.8"
 reqwest = { version = "0.10", features = ["json"]}
-hex = "0.4.2"
+hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
 

--- a/ledger-transport/Cargo.toml
+++ b/ledger-transport/Cargo.toml
@@ -31,6 +31,7 @@ ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
 # For not wasm compilation (native rust) compiling
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ledger-transport-hid = { path = "../ledger-transport-hid", version = "0.7.0" }
+ledger-transport-tcp = { path = "../ledger-transport-tcp", version = "0.7.0" }
 ledger-transport-zemu = { path = "../ledger-transport-zemu", version = "0.7.0" }
 
 # For wasm compiling

--- a/ledger-transport/Cargo.toml
+++ b/ledger-transport/Cargo.toml
@@ -15,24 +15,29 @@ autobenches = false
 [badges]
 circle-ci = { repository = "zondax/ledger-rs" }
 
+[features]
+default= ["transport-hid", "transport-tcp", "transport-zemu"]
+transport-hid = ["ledger-transport-hid", "futures"]
+transport-tcp = ["ledger-transport-tcp"]
+transport-zemu = ["ledger-transport-zemu"]
+
 [lib]
 name = "ledger_transport"
 
 [dependencies]
 byteorder = "1.3"
 lazy_static = "1.2"
-futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-trait-async = "0.1.24"
-
+trait-async = "0.1"
 ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
 
 # For not wasm compilation (native rust) compiling
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ledger-transport-hid = { path = "../ledger-transport-hid", version = "0.7.0" }
-ledger-transport-tcp = { path = "../ledger-transport-tcp", version = "0.7.0" }
-ledger-transport-zemu = { path = "../ledger-transport-zemu", version = "0.7.0" }
+ledger-transport-hid = { path = "../ledger-transport-hid", version = "0.7.0", optional=true }
+ledger-transport-tcp = { path = "../ledger-transport-tcp", version = "0.7.0" , optional=true }
+ledger-transport-zemu = { path = "../ledger-transport-zemu", version = "0.7.0", optional=true }
+futures = { version="0.3", optional=true }
 
 # For wasm compiling
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ledger-transport/src/lib.rs
+++ b/ledger-transport/src/lib.rs
@@ -85,4 +85,14 @@ pub mod exchange {
                 .map_err(|_| TransportError::APDUExchangeError)
         }
     }
+
+    #[trait_async]
+    impl Exchange for ledger_tcp::TransportTcp {
+        async fn exchange(&self, command: &APDUCommand) -> Result<APDUAnswer, TransportError> {
+            use ledger_tcp::TransportTcp;
+            TransportTcp::exchange(self, command)
+                .await
+                .map_err(|_| TransportError::APDUExchangeError)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds TCP as a Ledger transport option, making it easy to use the [`speculos` Ledger emulator](https://github.com/LedgerHQ/speculos).

In addition, the different transports are feature-gated, but all included as defaults. This makes it easy for users to disable certain transports; I wanted this so I could avoid the protoc install and zemu transport building in my CI, but also makes it easy to avoid the tokio dependency introduce by the TCP transport.

I also found the revision constraints in the Toml to be rather restrictive, so I've loosened those. I hope that's ok, but happy to revert that change if you have reason for it.

<!-- ClickUpRef: 2karmvx -->
:link: [zboto Link](https://app.clickup.com/t/2karmvx)