### PR TITLE
ledger-transport: fix build error from doc attr

### DIFF
--- a/ledger-transport/src/apdu_transport_native.rs
+++ b/ledger-transport/src/apdu_transport_native.rs
@@ -18,7 +18,6 @@
 #![deny(warnings, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_import_braces, unused_qualifications)]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/ledger-filecoin/0.1.0")]
 
 use crate::errors::TransportError;
 use crate::Exchange;

--- a/ledger-transport/src/apdu_transport_wasm.rs
+++ b/ledger-transport/src/apdu_transport_wasm.rs
@@ -14,10 +14,9 @@
 *  limitations under the License.
 ********************************************************************************/
 
-// #![deny(warnings, trivial_casts, trivial_numeric_casts)]
-// #![deny(unused_import_braces, unused_qualifications)]
-// #![deny(missing_docs)]
-// #![doc(html_root_url = "https://docs.rs/ledger-filecoin/0.1.0")]
+#![deny(warnings, trivial_casts, trivial_numeric_casts)]
+#![deny(unused_import_braces, unused_qualifications)]
+#![deny(missing_docs)]
 
 use crate::errors::TransportError;
 use ledger_apdu::{APDUAnswer, APDUCommand};


### PR DESCRIPTION
The `#[doc(html_root_url = "...")]` attribute can now only be applied at the crate level, tested with rustc 1.56.1 stable. `#![deny(warnings)]` further turns this warning into an error. Removing the `html_root_url` doc attribute. The commented deny attributes in the wasm module are uncommented too.