### PR TITLE
ledger-transport-hid: fix RUSTSEC-2021-0119

### DIFF
--- a/ledger-transport-hid/Cargo.toml
+++ b/ledger-transport-hid/Cargo.toml
@@ -29,7 +29,7 @@ ledger-apdu = { path = "../ledger-apdu", version = "0.7.0" }
 log = "0.4.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = "0.17.0"
+nix = "0.23.0"
 
 [dependencies.hidapi]
 version = "1.2.3"


### PR DESCRIPTION
Fix "Out-of-bounds write in nix::unistd::getgrouplist" by upgrading nix to the latest release. See:

- https://rustsec.org/advisories/RUSTSEC-2021-0119.html

Although the crate is actually unaffected (`getgrouplist` is not used), but having one error eliminated in `cargo audit` result is always good :)

Note that there are more; this only addresses the report we received at https://github.com/iotaledger/wallet.rs/issues/778.