### PR TITLE
Added TCP transport for use with `speculos`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ledger-transport",
     "ledger-transport-hid",
     "ledger-transport-zemu",
+    "ledger-transport-tcp",
     "ledger-zondax-generic",
 ]
 
@@ -20,4 +21,5 @@ ledger-apdu = { path = "ledger-apdu" }
 ledger-transport = { path = "ledger-transport" }
 ledger-transport-hid = { path = "ledger-transport-hid" }
 ledger-transport-zemu = { path = "ledger-transport-zemu" }
+ledger-transport-tcp = { path = "ledger-transport-tcp" }
 ledger-zondax-generic = { path = "ledger-zondax-generic" }

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -12,16 +12,13 @@ keywords = ["ledger", "nano", "blue", "apdu", "tcp"]
 edition = "2021"
 
 [features]
-default = [ "clap" ]
+default = []
 
 [dependencies]
 thiserror = "1.0"
 log = "0.4"
 async-trait = "0.1.56"
-
 byteorder = "1.4.3"
-
-humantime = "2.1.0"
 
 ledger-transport = "0.10"
 tokio = { version = "1.20.1", features = [ "net", "time" ] }

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ledger-transport-tcp"
+description = "Ledger Hardware Wallet - TCP (Speculos) Transport"
+version = "0.10.0"
+license = "Apache-2.0"
+authors = ["Linfeng Yuan <linfeng@crypto.com>"]
+homepage = "https://github.com/zondax/ledger-rs"
+repository = "https://github.com/zondax/ledger-rs"
+readme = "README.md"
+categories  = ["authentication", "cryptography"]
+keywords = ["ledger", "nano", "blue", "apdu", "tcp"]
+edition = "2021"
+
+[features]
+default = [ "clap" ]
+
+[dependencies]
+thiserror = "1.0"
+log = "0.4"
+async-trait = "0.1.56"
+
+byteorder = "1.4.3"
+
+humantime = "2.1.0"
+
+ledger-transport = "0.10"
+tokio = { version = "1.20.1", features = [ "net", "time" ] }
+
+clap = { version = "3.2.15", features = [ "derive", "env" ], optional = true }
+

--- a/ledger-transport-tcp/src/error.rs
+++ b/ledger-transport-tcp/src/error.rs
@@ -4,9 +4,6 @@ pub enum Error {
     #[error("IO error {:?}", 0)]
     Io(std::io::Error),
 
-    #[error("Connection failed: {:?}", 0)]
-    Connection(std::io::Error),
-
     #[error("Command timeout")]
     Timeout,
 

--- a/ledger-transport-tcp/src/error.rs
+++ b/ledger-transport-tcp/src/error.rs
@@ -1,0 +1,30 @@
+/// Speculos (TCP) transport errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("IO error {:?}", 0)]
+    Io(std::io::Error),
+
+    #[error("Connection failed: {:?}", 0)]
+    Connection(std::io::Error),
+
+    #[error("Command timeout")]
+    Timeout,
+
+    #[error("Invalid response length")]
+    InvalidLength,
+
+    #[error("Invalid answer APDU")]
+    InvalidAnswer,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        Error::Timeout
+    }
+}

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -1,0 +1,118 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    ops::Deref,
+    time::Duration,
+};
+
+use byteorder::{ByteOrder, NetworkEndian};
+use ledger_transport::{APDUAnswer, APDUCommand, Exchange};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    sync::Mutex,
+};
+
+mod error;
+pub use error::Error;
+
+/// Ledger speculos (TCP) transport
+pub struct TransportTcp {
+    s: Mutex<TcpStream>,
+    timeout: Duration,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+pub struct TcpOptions {
+    /// IP Address for TCP connection
+    #[cfg_attr(feature = "clap", clap(long, default_value = "127.0.0.1", env))]
+    pub addr: IpAddr,
+
+    /// Port for TCP connection
+    #[cfg_attr(feature = "clap", clap(long, default_value = "1237", env))]
+    pub port: u16,
+
+    /// Request/Response timeout
+    #[cfg_attr(feature = "clap", clap(long, default_value = "3s", env))]
+    pub timeout: humantime::Duration,
+}
+
+impl TransportTcp {
+    /// Create a new speculos (TCP) transport
+    pub async fn new(o: TcpOptions) -> Result<Self, Error> {
+        let addr = SocketAddr::new(o.addr, o.port);
+
+        log::debug!("Using socket: {}", addr);
+
+        let s = match TcpStream::connect(addr).await {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("Failed to connect to TCP socket: {}", addr);
+                return Err(Error::Connection(e));
+            }
+        };
+
+        log::debug!("Socket bound ({:?})", s.local_addr());
+
+        Ok(Self {
+            s: Mutex::new(s),
+            timeout: *o.timeout,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Exchange for TransportTcp {
+    type Error = Error;
+    type AnswerType = Vec<u8>;
+
+    async fn exchange<I>(
+        &self,
+        command: &APDUCommand<I>,
+    ) -> Result<APDUAnswer<Self::AnswerType>, Self::Error>
+    where
+        I: Deref<Target = [u8]> + Send + Sync,
+    {
+        let mut s = self.s.lock().await;
+
+        // Encode command object
+        let out = command.serialize();
+
+        let mut buff = vec![0u8; out.len() + 4];
+        NetworkEndian::write_u32(&mut buff, out.len() as u32);
+        buff[4..].copy_from_slice(&out);
+
+        log::debug!("Sending command: {:02x?} ({})", out, out.len());
+
+        // Send command
+        s.write(&buff).await?;
+
+        // Await response
+        let mut buff = [0u8; 4];
+
+        log::debug!("Awaiting response...");
+
+        // Read length header
+        let len = match tokio::time::timeout(self.timeout, s.read(&mut buff)).await?? {
+            4 => NetworkEndian::read_u32(&buff[..4]),
+            _ => return Err(Error::InvalidLength),
+        };
+
+        log::debug!("Expected {} byte response", len);
+
+        // Read response body
+        let mut buff = vec![0u8; len as usize + 2];
+        tokio::time::timeout(self.timeout, s.read_exact(&mut buff)).await??;
+
+        log::debug!("Received answer: {:02x?} ({})", buff, len);
+
+        // Decode answer ADPU
+        let answer = APDUAnswer::from_answer(buff).map_err(|_| Error::InvalidAnswer)?;
+
+        log::debug!("Decoded APDU: {:02x?}", answer);
+
+        // Return ADPU
+        Ok(answer)
+    }
+}

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::Deref,
     time::Duration,
 };
@@ -16,26 +16,38 @@ use tokio::{
 mod error;
 pub use error::Error;
 
-/// Ledger speculos (TCP) transport
+/// Ledger TCP (speculos) ADPU transport
 pub struct TransportTcp {
     s: Mutex<TcpStream>,
     timeout: Duration,
 }
 
+/// Configuration options for [`TransportTcp`]
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct TcpOptions {
-    /// IP Address for TCP connection
-    #[cfg_attr(feature = "clap", clap(long, default_value = "127.0.0.1", env))]
+    /// TCP address for ADPU connection
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = TcpOptions::default().addr, env = "TCP_ADDR"))]
     pub addr: IpAddr,
 
-    /// Port for TCP connection
-    #[cfg_attr(feature = "clap", clap(long, default_value = "1237", env))]
+    /// TCP port for ADPU connection
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = TcpOptions::default().port, env = "TCP_PORT"))]
     pub port: u16,
 
-    /// Request/Response timeout
-    #[cfg_attr(feature = "clap", clap(long, default_value = "3s", env))]
-    pub timeout: humantime::Duration,
+    /// ADPU timeout in milliseconds
+    #[cfg_attr(feature = "clap", clap(default_value_t = TcpOptions::default().timeout_ms, env = "TCP_TIMEOUT_MS"))]
+    pub timeout_ms: u64,
+}
+
+/// Default configuration for [`TransportTcp`]
+impl Default for TcpOptions {
+    fn default() -> Self {
+        Self {
+            addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            port: 1237,
+            timeout_ms: 3000,
+        }
+    }
 }
 
 impl TransportTcp {
@@ -45,19 +57,21 @@ impl TransportTcp {
 
         log::debug!("Using socket: {}", addr);
 
+        // Bind TCP connection
         let s = match TcpStream::connect(addr).await {
             Ok(s) => s,
             Err(e) => {
                 log::warn!("Failed to connect to TCP socket: {}", addr);
-                return Err(Error::Connection(e));
+                return Err(Error::Io(e));
             }
         };
 
         log::debug!("Socket bound ({:?})", s.local_addr());
 
+        // Build object
         Ok(Self {
             s: Mutex::new(s),
-            timeout: *o.timeout,
+            timeout: Duration::from_millis(o.timeout_ms),
         })
     }
 }
@@ -67,6 +81,7 @@ impl Exchange for TransportTcp {
     type Error = Error;
     type AnswerType = Vec<u8>;
 
+    /// Exchange an ADPU with via the TCP transport
     async fn exchange<I>(
         &self,
         command: &APDUCommand<I>,


### PR DESCRIPTION
a simple tokio based TCP transport impl, for use with `speculos`'s `--apdu-port`.

(also wondering whether y'all are open to other changes / improvements before i dig too far into this?)

<!-- ClickUpRef: 2u483x3 -->
:link: [zboto Link](https://app.clickup.com/t/2u483x3)