### PR TITLE
an alternate approach to APDU encoding/decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ledger-transport",
     "ledger-transport-hid",
     "ledger-transport-zemu",
+    "ledger-transport-tcp",
     "ledger-zondax-generic",
 ]
 
@@ -20,4 +21,5 @@ ledger-apdu = { path = "ledger-apdu" }
 ledger-transport = { path = "ledger-transport" }
 ledger-transport-hid = { path = "ledger-transport-hid" }
 ledger-transport-zemu = { path = "ledger-transport-zemu" }
+ledger-transport-tcp = { path = "ledger-transport-tcp" }
 ledger-zondax-generic = { path = "ledger-zondax-generic" }

--- a/ledger-apdu/Cargo.toml
+++ b/ledger-apdu/Cargo.toml
@@ -18,10 +18,13 @@ default = ["std"]
 [dependencies]
 arrayref = "0.3.6"
 no-std-compat = "0.4.1"
-snafu = { version = "0.7", features = ["rust_1_46"], default-features = false }
+snafu = { version = "0.7", features = ["rust_1_46"], default_features = false }
 bitflags = "1.3.2"
 num_enum = "0.5.7"
 byteorder = "1.4.3"
+
+# Optionally enable serde for APDUs
+serde = { version = "1.0.140", default_features = false, features = [ "derive" ], optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/ledger-apdu/Cargo.toml
+++ b/ledger-apdu/Cargo.toml
@@ -12,16 +12,19 @@ keywords = ["ledger", "nano", "blue", "apdu"]
 edition = "2021"
 
 [features]
-std = ["snafu/std", "no-std-compat/std"]
+std = ["snafu/std", "no-std-compat/std", "thiserror" ]
 default = ["std"]
 
 [dependencies]
 arrayref = "0.3.6"
 no-std-compat = "0.4.1"
 snafu = { version = "0.7", features = ["rust_1_46"], default_features = false }
+thiserror = { version = "1.0.35", default_features = false, optional = true }
 bitflags = "1.3.2"
 num_enum = { version = "0.5.7", default_features = false }
 byteorder = { version = "1.4.3", default_features = false }
+strum = { version = "0.24.1", default_features = false, features = [ "derive" ] }
+encdec = "0.6.1"
 
 # Optionally enable serde for APDUs
 serde = { version = "1.0.140", default_features = false, features = [ "derive" ], optional = true }

--- a/ledger-apdu/Cargo.toml
+++ b/ledger-apdu/Cargo.toml
@@ -20,8 +20,8 @@ arrayref = "0.3.6"
 no-std-compat = "0.4.1"
 snafu = { version = "0.7", features = ["rust_1_46"], default_features = false }
 bitflags = "1.3.2"
-num_enum = "0.5.7"
-byteorder = "1.4.3"
+num_enum = { version = "0.5.7", default_features = false }
+byteorder = { version = "1.4.3", default_features = false }
 
 # Optionally enable serde for APDUs
 serde = { version = "1.0.140", default_features = false, features = [ "derive" ], optional = true }

--- a/ledger-apdu/Cargo.toml
+++ b/ledger-apdu/Cargo.toml
@@ -19,3 +19,9 @@ default = ["std"]
 arrayref = "0.3.6"
 no-std-compat = "0.4.1"
 snafu = { version = "0.7", features = ["rust_1_46"], default-features = false }
+bitflags = "1.3.2"
+num_enum = "0.5.7"
+byteorder = "1.4.3"
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/ledger-apdu/Cargo.toml
+++ b/ledger-apdu/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ledger", "nano", "blue", "apdu"]
 edition = "2021"
 
 [features]
-std = ["snafu/std", "no-std-compat/std", "thiserror" ]
+std = ["snafu/std", "no-std-compat/std", "thiserror", "encdec/std" ]
 default = ["std"]
 
 [dependencies]
@@ -24,7 +24,7 @@ bitflags = "1.3.2"
 num_enum = { version = "0.5.7", default_features = false }
 byteorder = { version = "1.4.3", default_features = false }
 strum = { version = "0.24.1", default_features = false, features = [ "derive" ] }
-encdec = "0.6.1"
+encdec = { version = "0.8.0", default_features = false }
 
 # Optionally enable serde for APDUs
 serde = { version = "1.0.140", default_features = false, features = [ "derive" ], optional = true }

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -19,6 +19,8 @@ impl ApduEmpty for AppInfoGet {}
 
 /// Application information APDU response
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all="camelCase"))]
 pub struct AppInfo<'a> {
     /// Application name
     pub name: &'a str,
@@ -30,6 +32,7 @@ pub struct AppInfo<'a> {
 
 bitflags::bitflags! {
     /// Application info flags
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct AppFlags: u8 {
         const RECOVERY = 0x01;
         const SIGNED = 0x02;

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -1,7 +1,7 @@
 
-use crate::{ApduStatic, ApduBase, ApduError};
+use crate::{ApduStatic, ApduError};
 
-use encdec::{Encode, Decode, Error};
+use encdec::{Encode, Decode};
 /// Application info APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default, Encode, Decode)]
 #[encdec(error="ApduError")]

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -1,7 +1,7 @@
 
 use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
 
-/// Application info ADPU command
+/// Application info APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct AppInfoGet {}
 

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -34,9 +34,13 @@ bitflags::bitflags! {
     /// Application info flags
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct AppFlags: u8 {
+        /// Recovery mode
         const RECOVERY = 0x01;
+        /// Signed application
         const SIGNED = 0x02;
+        /// User onboarded
         const ONBOARDED = 0x04;
+        /// PIN validated
         const PIN_VALIDATED = 0xF0;
     }
 }

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -80,8 +80,9 @@ impl <'a>Encode for AppInfo<'a> {
 
     /// Compute APDU encoded length
     fn encode_len(&self) -> Result<usize, ApduError> {
-        let mut len = 4;
+        let mut len = 0;
 
+        len += 1;
         len += 1 + self.name.len();
         len += 1 + self.version.len();
         len += 2;
@@ -118,8 +119,9 @@ impl <'a>Decode<'a> for AppInfo<'a> {
         index += 1 + version_len;
 
         // Fetch flags
-        let _flags_len = buff[index];
+        let flags_len = buff[index];
         let flags = AppFlags::from_bits_truncate(buff[index + 1]);
+        index += 1 + flags_len as usize;
 
         Ok((Self{ name, version, flags }, index))
     }

--- a/ledger-apdu/src/apdus/app_info.rs
+++ b/ledger-apdu/src/apdus/app_info.rs
@@ -1,0 +1,129 @@
+
+use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
+
+/// Application info ADPU command
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct AppInfoGet {}
+
+impl <'a> ApduCmd<'a> for AppInfoGet {
+    /// Application Info command APDU is class `0xb0`
+    const CLA: u8 = 0xb0;
+
+    /// Application Info GET APDU is instruction `0x00`
+    const INS: u8 = 0x01;
+}
+
+/// [`AppInfoGet`] APDU command has no body
+impl ApduEmpty for AppInfoGet {}
+
+
+/// Application information APDU response
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct AppInfo<'a> {
+    /// Application name
+    pub name: &'a str,
+    /// Application version
+    pub version: &'a str,
+    /// Application flags
+    pub flags: AppFlags,
+}
+
+bitflags::bitflags! {
+    /// Application info flags
+    pub struct AppFlags: u8 {
+        const RECOVERY = 0x01;
+        const SIGNED = 0x02;
+        const ONBOARDED = 0x04;
+        const PIN_VALIDATED = 0xF0;
+    }
+}
+
+const APP_VERSION_FMT: u8 = 1;
+
+impl <'a> AppInfo<'a> {
+    /// Create a new application version APDU
+    pub fn new(name: &'a str, version: &'a str, flags: AppFlags) -> Self {
+        Self{ name, version, flags }
+    }
+}
+
+impl <'a>ApduBase<'a> for AppInfo<'a> {
+    /// Encode an app version APDU into the provided buffer
+    fn encode(&self, buff: &mut [u8]) -> usize {
+        // TODO: check buffer length is viable
+
+        let mut index = 0;
+        buff[0] = APP_VERSION_FMT;
+        index += 1;
+
+        buff[index] = self.name.len() as u8;
+        buff[index + 1..][..self.name.len()].copy_from_slice(self.name.as_bytes());
+        index += 1 + self.name.len();
+
+        buff[index] = self.version.len() as u8;
+        buff[index + 1..][..self.version.len()].copy_from_slice(self.version.as_bytes());
+        index += 1 + self.version.len();
+
+        buff[index] = 1;
+        buff[index + 1] = self.flags.bits();
+        index += 2;
+
+        return index;
+            
+    }
+
+    /// Decode an app version APDU from the provided buffer
+    fn decode(buff: &'a [u8]) -> Result<Self, ApduError> {
+        let mut index = 0;
+        let buff = buff.as_ref();
+
+        // Check app version format
+        if buff[index] != APP_VERSION_FMT {
+            return Err(ApduError::InvalidVersion(buff[index]));
+        }
+        index += 1;
+
+        // Fetch name string
+        let name_len = buff[index] as usize;
+        let name = core::str::from_utf8(&buff[index + 1..][..name_len])
+            .map_err(|_| ApduError::Utf8 )?;
+        index += 1 + name_len;
+
+        // Fetch version string
+        let version_len = buff[index] as usize;
+        let version = core::str::from_utf8(&buff[index + 1..][..version_len])
+            .map_err(|_| ApduError::Utf8 )?;
+        index += 1 + version_len;
+
+        // Fetch flags
+        let _flags_len = buff[index];
+        let flags = AppFlags::from_bits_truncate(buff[index + 1]);
+
+        Ok(Self{ name, version, flags })
+    }
+}
+
+#[cfg(test)]
+mod test {    
+    use crate::test::encode_decode_apdu;
+    use super::*;
+
+    #[test]
+    fn app_info_get_apdu() {
+        let apdu = AppInfoGet::default();
+
+        let mut buff = [0u8; 128];
+        encode_decode_apdu(&mut buff, &apdu);
+    }
+
+    #[test]
+    fn app_info_apdu() {
+        let name = "TEST NAME";
+        let version = "TEST VERSION";
+
+        let apdu = AppInfo::new(name, version, AppFlags::ONBOARDED);
+
+        let mut buff = [0u8; 128];
+        encode_decode_apdu(&mut buff, &apdu);
+    }
+}

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -1,7 +1,7 @@
 
 use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
 
-/// Device info ADPU command
+/// Device info APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct DeviceInfoGet {}
 

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -1,7 +1,7 @@
 
 use encdec::{Encode, Decode};
 
-use crate::{ApduStatic, ApduBase, ApduError};
+use crate::{ApduStatic, ApduError};
 
 /// Device info APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default, Encode, Decode)]

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -19,6 +19,8 @@ impl ApduEmpty for DeviceInfoGet {}
 
 /// Device information APDU response
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all="camelCase"))]
 pub struct DeviceInfo<'a> {
     /// Target ID
     #[cfg_attr(features = "serde", serde(rename(serialize = "targetId")))]

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -1,0 +1,142 @@
+
+use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
+
+/// Device info ADPU command
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct DeviceInfoGet {}
+
+impl <'a> ApduCmd<'a> for DeviceInfoGet {
+    /// Device Info command APDU is class `0xe0`
+    const CLA: u8 = 0xe0;
+
+    /// Device Info GET APDU is instruction `0x01`
+    const INS: u8 = 0x01;
+}
+
+/// [`DeviceInfoGet`] APDU command has no body
+impl ApduEmpty for DeviceInfoGet {}
+
+
+/// Device information APDU response
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct DeviceInfo<'a> {
+    /// Target ID
+    #[cfg_attr(features = "serde", serde(rename(serialize = "targetId")))]
+    pub target_id: [u8; 4],
+
+    /// Secure Element Version
+    #[cfg_attr(features = "serde", serde(rename(serialize = "seVersion")))]
+    pub se_version: &'a str,
+    
+    /// Device Flag(s)
+    pub flag: &'a[u8],
+    
+    /// MCU Version
+    #[cfg_attr(features = "serde", serde(rename(serialize = "mcuVersion")))]
+    pub mcu_version: &'a str,
+}
+
+bitflags::bitflags! {
+    /// Device info flags
+    pub struct DeviceFlags: u8 {
+        const TODO = 0x01;
+    }
+}
+
+const APP_VERSION_FMT: u8 = 1;
+
+impl <'a> DeviceInfo<'a> {
+    /// Create a new device info APDU
+    pub fn new(target_id: [u8; 4], se_version: &'a str, mcu_version: &'a str, flag: &'a[u8]) -> Self {
+        Self{ target_id, se_version, mcu_version, flag }
+    }
+}
+
+impl <'a>ApduBase<'a> for DeviceInfo<'a> {
+    /// Encode an device info APDU into the provided buffer
+    fn encode(&self, buff: &mut [u8]) -> usize {
+        // TODO: check buffer length is viable
+
+        let mut index = 0;
+
+        // Write target ID
+        buff[index..][..4].copy_from_slice(&self.target_id);
+        index += 4;
+
+        // Write SE version
+        buff[index] = self.se_version.len() as u8;
+        buff[index + 1..][..self.se_version.len()].copy_from_slice(self.se_version.as_bytes());
+        index += 1 + self.se_version.len();
+
+        // Write flags
+        buff[index] = self.flag.len() as u8;
+        buff[index + 1..][..self.flag.len()].copy_from_slice(self.flag);
+        index += 1 + self.flag.len();
+
+        // Write MCU version
+        buff[index] = self.mcu_version.len() as u8;
+        buff[index + 1..][..self.mcu_version.len()].copy_from_slice(self.mcu_version.as_bytes());
+        index += 1 + self.mcu_version.len();
+        
+
+        return index;
+            
+    }
+
+    /// Decode an device info APDU from the provided buffer
+    fn decode(buff: &'a [u8]) -> Result<Self, ApduError> {
+        let mut index = 0;
+        let buff = buff.as_ref();
+
+        // Fetch target id
+        let mut target_id = [0u8; 4];
+        target_id.copy_from_slice(&buff[..4]);
+        index += 4;
+
+        // Fetch secure element version
+        let se_version_len = buff[index] as usize;
+        let se_version = core::str::from_utf8(&buff[index + 1..][..se_version_len])
+            .map_err(|_| ApduError::Utf8 )?;
+        index += 1 + se_version_len;
+
+        // Fetch flags
+        let flags_len = buff[index] as usize;
+        let flag = &buff[index + 1..][..flags_len];
+        index += 1 + flags_len;
+
+        // Fetch mcu version
+        let mcu_version_len = buff[index] as usize;
+        let mcu_version = core::str::from_utf8(&buff[index + 1..][..mcu_version_len])
+            .map_err(|_| ApduError::Utf8 )?;
+        index += 1 + se_version_len;
+
+        Ok(Self{ target_id, se_version, flag, mcu_version })
+    }
+}
+
+#[cfg(test)]
+mod test {    
+    use crate::test::encode_decode_apdu;
+    use super::*;
+
+    #[test]
+    fn device_info_get_apdu() {
+        let apdu = DeviceInfoGet::default();
+
+        let mut buff = [0u8; 128];
+        encode_decode_apdu(&mut buff, &apdu);
+    }
+
+    #[test]
+    fn device_info_apdu() {
+        let se = "SOME SE";
+        let mcu = "SOME MCU";
+        let flags = [12u8];
+        let target = [0xab; 4];
+
+        let apdu = DeviceInfo::new(target, se, mcu, &flags);
+
+        let mut buff = [0u8; 128];
+        encode_decode_apdu(&mut buff, &apdu);
+    }
+}

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -38,14 +38,6 @@ pub struct DeviceInfo<'a> {
     pub mcu_version: &'a str,
 }
 
-bitflags::bitflags! {
-    /// Device info flags
-    pub struct DeviceFlags: u8 {
-        const TODO = 0x01;
-    }
-}
-
-const APP_VERSION_FMT: u8 = 1;
 
 impl <'a> DeviceInfo<'a> {
     /// Create a new device info APDU

--- a/ledger-apdu/src/apdus/device_info.rs
+++ b/ledger-apdu/src/apdus/device_info.rs
@@ -120,9 +120,7 @@ impl <'a>Decode<'a> for DeviceInfo<'a> {
         let mcu_version_len = buff[index] as usize;
         let mcu_version = core::str::from_utf8(&buff[index + 1..][..mcu_version_len])
             .map_err(|_| ApduError::Utf8 )?;
-        index += 1 + se_version_len;
-
-        let _ = index;
+        index += 1 + mcu_version_len;
 
         Ok((Self{ target_id, se_version, flag, mcu_version }, index))
     }

--- a/ledger-apdu/src/apdus/mod.rs
+++ b/ledger-apdu/src/apdus/mod.rs
@@ -13,7 +13,7 @@ pub use version::*;
 mod device_info;
 pub use device_info::*;
 
-use crate::{ApduBase, ApduCmd, ApduHeader, ApduError};
+use crate::{ApduCmd, ApduHeader, ApduError};
 
 /// Empty APDU for exchanges where no response data is expected
 #[derive(Clone, PartialEq, Default, Debug, Encode, Decode)]

--- a/ledger-apdu/src/apdus/mod.rs
+++ b/ledger-apdu/src/apdus/mod.rs
@@ -1,0 +1,9 @@
+
+mod app_info;
+pub use app_info::*;
+
+mod version;
+pub use version::*;
+
+mod device_info;
+pub use device_info::*;

--- a/ledger-apdu/src/apdus/mod.rs
+++ b/ledger-apdu/src/apdus/mod.rs
@@ -1,3 +1,4 @@
+//! Shared APDU definitions
 
 mod app_info;
 pub use app_info::*;

--- a/ledger-apdu/src/apdus/mod.rs
+++ b/ledger-apdu/src/apdus/mod.rs
@@ -1,5 +1,9 @@
 //! Shared APDU definitions
 
+use core::fmt::Debug;
+
+use encdec::{Encode, Decode};
+
 mod app_info;
 pub use app_info::*;
 
@@ -8,3 +12,73 @@ pub use version::*;
 
 mod device_info;
 pub use device_info::*;
+
+use crate::{ApduBase, ApduCmd, ApduHeader, ApduError};
+
+/// Empty APDU for exchanges where no response data is expected
+#[derive(Clone, PartialEq, Default, Debug, Encode, Decode)]
+#[encdec(error="ApduError")]
+pub struct Empty;
+
+
+/// Generic APDU passes through slices for manual construction of messages
+#[derive(Clone, PartialEq, Debug)]
+pub struct Generic<'a>{
+    /// APDU application class
+    pub cla: u8,
+    /// APDU instruction
+    pub ins: u8,
+    /// p1 value if set
+    pub p1: u8,
+    /// p2 value if set
+    pub p2: u8,
+    /// Slice of data to send
+    pub data: &'a [u8],
+}
+
+impl <'a> Generic<'a> {
+    /// Create a new generic APDU
+    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8, data: &'a [u8]) -> Self {
+        Self{ cla, ins, p1, p2, data }
+    }
+}
+
+impl <'a> Encode for Generic<'a> {
+    type Error = ApduError;
+    
+    fn encode(&self, buff: &mut [u8]) -> Result<usize, ApduError> {
+        if buff.len() < self.data.len() {
+            return Err(ApduError::InvalidLength);
+        }
+
+        buff[..self.data.len()].copy_from_slice(&self.data);
+
+        Ok(self.data.len())
+    }
+
+    fn encode_len(&self) -> Result<usize, ApduError> {
+        Ok(self.data.len())
+    }
+}
+
+
+impl <'a> Decode<'a> for Generic<'a> {
+    type Output = Self;
+    type Error = ApduError;
+
+    fn decode(buff: &'a [u8]) -> Result<(Self::Output, usize), Self::Error> {
+        Ok((Self{data: buff, cla: 0, ins: 0, p1: 0, p2: 0}, 0))
+    }
+}
+
+impl <'a> ApduCmd<'a> for Generic<'a> {
+    fn header(&self) -> ApduHeader {
+        ApduHeader { 
+            cla: self.cla, 
+            ins: self.ins, 
+            p1: self.p1, 
+            p2: self.p2, 
+            len: self.encode_len().unwrap() as u8,
+        }
+    }
+}

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -48,14 +48,19 @@ impl Version {
     }
 }
 
+/// Version encoding mode
 #[derive(Copy, Clone, PartialEq, Debug, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all="camelCase"))]
 #[repr(u8)]
 pub enum VersionMode {
+    /// Single byte version numbers
     SingleByte = 0x04,
+    /// Two byte version numbers
     DoubleByte = 0x07,
+    /// Single byte version numbers with flags and target_id
     SingleBytePlus = 0x09,
+    /// Two byte version numbers with flags and target_id
     DoubleBytePlus = 0x0c,
 }
 

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -1,0 +1,181 @@
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use byteorder::{ByteOrder, NetworkEndian};
+
+use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
+
+/// Version ADPU command
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct VersionGet<const CLA: u8 = 0x00> {}
+
+impl <'a, const CLA: u8> ApduCmd<'a> for VersionGet<CLA> {
+    /// Version command class defined by application
+    const CLA: u8 = CLA;
+
+    /// Application Version GET APDU is instruction 0
+    const INS: u8 = 0x00;
+}
+
+/// [`VersionGet`] APDU command has no body
+impl <const CLA: u8> ApduEmpty for VersionGet<CLA> {}
+
+
+/// Application information APDU response
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Version {
+    /// Application Mode
+    #[cfg_attr(features = "serde", serde(rename(serialize = "testMode")))]
+    pub mode: VersionMode,
+    /// Version Major
+    pub major: u16,
+    /// Version Minor
+    pub minor: u16,
+    /// Version Patch
+    pub patch: u16,
+    /// Device is locked
+    pub locked: bool,
+    /// Target ID
+    pub target_id: [u8; 4],
+}
+
+
+impl Version {
+    /// Create a new application version APDU
+    pub fn new(mode: VersionMode, major: u16, minor: u16, patch: u16, locked: bool, target_id: [u8; 4]) -> Self {
+        Self{ mode, major, minor, patch, locked, target_id }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum VersionMode {
+    SingleByte = 0x04,
+    DoubleByte = 0x07,
+    SingleBytePlus = 0x09,
+    DoubleBytePlus = 0x0c,
+}
+
+impl <'a>ApduBase<'a> for Version {
+    /// Encode an app version APDU into the provided buffer
+    fn encode(&self, buff: &mut [u8]) -> usize {
+        // TODO: check buffer length is viable
+
+        let mut index = 0;
+        
+        // Write mode
+        buff[index] = self.mode.into();
+        index += 1;
+
+        // Write version numbers
+        match self.mode {
+            VersionMode::SingleByte | VersionMode::SingleBytePlus => {
+                buff[index + 0] = self.major as u8;
+                buff[index + 1] = self.minor as u8;
+                buff[index + 2] = self.patch as u8;
+                index += 3;
+            },
+            VersionMode::DoubleByte | VersionMode::DoubleBytePlus => {
+                NetworkEndian::write_u16(&mut buff[index + 0..], self.major);
+                NetworkEndian::write_u16(&mut buff[index + 2..], self.minor);
+                NetworkEndian::write_u16(&mut buff[index + 4..], self.patch);
+                index += 6;
+            },
+        };
+
+        // Write flags
+        match self.mode {
+            VersionMode::SingleBytePlus | VersionMode::DoubleBytePlus => {
+                if self.locked {
+                    buff[index] = 1;
+                } else {
+                    buff[index] = 0;
+                }
+                
+                buff[index+1..][..4].copy_from_slice(&self.target_id);
+                index += 5;
+            },
+            _ => (),
+        };
+
+
+        return index;
+            
+    }
+
+    /// Decode an app version APDU from the provided buffer
+    fn decode(buff: &'a [u8]) -> Result<Self, ApduError> {
+        let mut index = 0;
+
+        // Parse out mode
+        let mode = match VersionMode::try_from(buff[index]) {
+            Ok(v) => v,
+            Err(_) => return Err(ApduError::InvalidVersion(buff[index])),
+        };
+        index += 1;
+
+        // Parse out version numbers
+        let (major, minor, patch) = match mode {
+            VersionMode::SingleByte | VersionMode::SingleBytePlus => {
+                let (ma, mi, p) = (
+                    buff[index + 0] as u16,
+                    buff[index + 1] as u16,
+                    buff[index + 2] as u16,
+                );
+                index += 3;
+                (ma, mi, p)
+            },
+            VersionMode::DoubleByte | VersionMode::DoubleBytePlus => {
+                let (ma, mi, p) = (
+                    NetworkEndian::read_u16(&buff[index + 0..]),
+                    NetworkEndian::read_u16(&buff[index + 2..]),
+                    NetworkEndian::read_u16(&buff[index + 4..]),
+                );
+                index += 6;
+                (ma, mi, p)
+            },
+        };
+
+        // Parse out flags
+        let (locked, target_id) = match mode {
+            VersionMode::SingleBytePlus | VersionMode::DoubleBytePlus => {
+                let locked = buff[index] != 0;
+                let mut target_id = [0u8; 4];
+                target_id.copy_from_slice(&buff[index+1..][..4]);
+                (locked, target_id)
+            },
+            VersionMode::SingleByte | VersionMode::DoubleByte => (false, [0u8; 4]),
+        };
+
+        Ok(Self{ mode, major, minor, patch, locked, target_id })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test::encode_decode_apdu;
+    use super::*;
+
+    #[test]
+    fn version_get_apdu() {
+        let apdu = VersionGet::<0x12>::default();
+
+        let mut buff = [0u8; 128];
+        encode_decode_apdu(&mut buff, &apdu);
+    }
+
+    #[test]
+    fn version_apdu() {
+        // Test each mode
+        let tests = &[
+            Version::new(VersionMode::SingleByte, 10, 11, 12, false, [0x00; 4]),
+            Version::new(VersionMode::SingleBytePlus, 10, 11, 12, false, [0xaa; 4]),
+            Version::new(VersionMode::DoubleByte, 1010, 1011, 1012, false, [0x00; 4]),
+            Version::new(VersionMode::DoubleBytePlus, 1010, 1011, 1012, false, [0xaa; 4]),
+        ];
+
+        for t in tests {
+            let mut buff = [0u8; 128];
+            encode_decode_apdu(&mut buff, t);
+        }
+    }
+}

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -193,6 +193,8 @@ impl <'a> Decode<'a> for Version {
                 let locked = buff[index] != 0;
                 let mut target_id = [0u8; 4];
                 target_id.copy_from_slice(&buff[index+1..][..4]);
+
+                index += 5;
                 (locked, target_id)
             },
             VersionMode::SingleByte | VersionMode::DoubleByte => (false, [0u8; 4]),

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -22,6 +22,8 @@ impl <const CLA: u8> ApduEmpty for VersionGet<CLA> {}
 
 /// Application information APDU response
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all="camelCase"))]
 pub struct Version {
     /// Application Mode
     #[cfg_attr(features = "serde", serde(rename(serialize = "testMode")))]
@@ -47,6 +49,8 @@ impl Version {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all="camelCase"))]
 #[repr(u8)]
 pub enum VersionMode {
     SingleByte = 0x04,

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -3,7 +3,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use byteorder::{ByteOrder, NetworkEndian};
 use encdec::{Encode, Decode};
 
-use crate::{ApduStatic, ApduBase, ApduError};
+use crate::{ApduStatic, ApduError};
 
 /// Version APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default)]

--- a/ledger-apdu/src/apdus/version.rs
+++ b/ledger-apdu/src/apdus/version.rs
@@ -4,7 +4,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 
 use crate::{ApduCmd, ApduBase, ApduEmpty, ApduError};
 
-/// Version ADPU command
+/// Version APDU command
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct VersionGet<const CLA: u8 = 0x00> {}
 

--- a/ledger-apdu/src/error.rs
+++ b/ledger-apdu/src/error.rs
@@ -89,8 +89,8 @@ impl TryFrom<u16> for ApduErrorCode {
 impl From<encdec::Error> for ApduError {
     fn from(e: encdec::Error) -> Self {
         match e {
-            encdec::Error::BufferOverrun => ApduError::InvalidLength,
-            encdec::Error::Utf8Error => ApduError::Utf8,
+            encdec::Error::Length => ApduError::InvalidLength,
+            encdec::Error::Utf8 => ApduError::Utf8,
         }
     }
 }

--- a/ledger-apdu/src/error.rs
+++ b/ledger-apdu/src/error.rs
@@ -1,0 +1,90 @@
+use core::ops::Deref;
+use core::convert::{TryFrom, TryInto};
+
+use snafu::Snafu;
+
+/// APDU encode / decode errors
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum ApduError {
+    /// Invalid version / format identifier
+    InvalidVersion(u8),
+    /// Invalid UTF8 in string component
+    Utf8,
+    /// Invalid object length
+    InvalidLength,
+}
+
+
+#[derive(Copy, Clone, Debug, Snafu, PartialEq, Eq)]
+#[repr(u16)]
+/// Common known APDU error codes
+pub enum APDUErrorCode {
+    ///success
+    NoError = 0x9000,
+    ///error during apdu execution
+    ExecutionError = 0x6400,
+    ///apdu command wrong length
+    WrongLength = 0x6700,
+    ///empty apdu buffer
+    EmptyBuffer = 0x6982,
+    ///apdu buffer too small
+    OutputBufferTooSmall = 0x6983,
+    ///apdu parameters invalid
+    DataInvalid = 0x6984,
+    ///apdu preconditions not satisfied
+    ConditionsNotSatisfied = 0x6985,
+    ///apdu command not allowed
+    CommandNotAllowed = 0x6986,
+    ///apdu data field incorrect (bad key)
+    BadKeyHandle = 0x6A80,
+    ///apdu p1 or p2 incorrect
+    InvalidP1P2 = 0x6B00,
+    ///apdu instruction not supported or invalid
+    InsNotSupported = 0x6D00,
+    ///apdu class not supported or invalid
+    ClaNotSupported = 0x6E00,
+    ///unknown apdu error
+    Unknown = 0x6F00,
+    ///apdu sign verify error
+    SignVerifyError = 0x6F01,
+}
+
+#[cfg(feature = "std")]
+impl APDUErrorCode {
+    /// Quickhand to retrieve the error code's description / display
+    pub fn description(&self) -> std::string::String {
+        std::format!("{}", self)
+    }
+}
+
+impl From<APDUErrorCode> for u16 {
+    fn from(code: APDUErrorCode) -> Self {
+        code as u16
+    }
+}
+
+impl TryFrom<u16> for APDUErrorCode {
+    type Error = ();
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        let this = match value {
+            0x9000 => Self::NoError,
+            0x6400 => Self::ExecutionError,
+            0x6700 => Self::WrongLength,
+            0x6982 => Self::EmptyBuffer,
+            0x6983 => Self::OutputBufferTooSmall,
+            0x6984 => Self::DataInvalid,
+            0x6985 => Self::ConditionsNotSatisfied,
+            0x6986 => Self::CommandNotAllowed,
+            0x6A80 => Self::BadKeyHandle,
+            0x6B00 => Self::InvalidP1P2,
+            0x6D00 => Self::InsNotSupported,
+            0x6E00 => Self::ClaNotSupported,
+            0x6F00 => Self::Unknown,
+            0x6F01 => Self::SignVerifyError,
+            _ => return Err(()),
+        };
+
+        Ok(this)
+    }
+}

--- a/ledger-apdu/src/error.rs
+++ b/ledger-apdu/src/error.rs
@@ -12,6 +12,8 @@ pub enum ApduError {
     Utf8,
     /// Invalid object length
     InvalidLength,
+    /// Invalid object encoding
+    InvalidEncoding,
 }
 
 

--- a/ledger-apdu/src/lib.rs
+++ b/ledger-apdu/src/lib.rs
@@ -29,7 +29,7 @@ use snafu::prelude::*;
 #[cfg(test)]
 mod tests;
 
-mod apdus;
+pub mod apdus;
 
 mod error;
 pub use error::{ApduError, APDUErrorCode};

--- a/ledger-apdu/src/lib.rs
+++ b/ledger-apdu/src/lib.rs
@@ -22,7 +22,7 @@ extern crate no_std_compat as std;
 
 
 use core::{ops::Deref, fmt::Debug};
-use core::convert::{TryFrom, TryInto};
+use core::convert::{TryInto};
 
 use snafu::prelude::*;
 

--- a/ledger-apdu/src/lib.rs
+++ b/ledger-apdu/src/lib.rs
@@ -215,12 +215,15 @@ pub(crate) mod test {
 
     /// Helper for APDU encode / decode tests
     pub fn encode_decode_apdu<'a, A: ApduBase<'a>>(buff: &'a mut [u8], apdu: &A) {
-        let n = apdu.encode(buff);
+        let n = apdu.encode(buff)
+            .expect("encode failed");
 
-        assert_eq!(n, apdu.encode_len());
+        assert_eq!(n, apdu.encode_len().expect("encode_len failed"));
 
-        let decoded = A::decode(&buff[..n]).unwrap();
+        let (decoded, n1) = A::decode(&buff[..n])
+            .expect("decode failed");
 
         assert_eq!(apdu, &decoded);
+        assert_eq!(n, n1);
     }
 }

--- a/ledger-apdu/src/lib.rs
+++ b/ledger-apdu/src/lib.rs
@@ -24,7 +24,7 @@ extern crate no_std_compat as std;
 use core::{ops::Deref, fmt::Debug};
 use core::convert::{TryInto};
 
-use encdec::{EncDec};
+
 use snafu::prelude::*;
 
 #[cfg(test)]

--- a/ledger-apdu/src/tests.rs
+++ b/ledger-apdu/src/tests.rs
@@ -52,7 +52,7 @@ fn apdu_answer_success() {
     let answer = APDUAnswer::from_answer(APDU_RESPONSE).expect("valid answer length >= 2");
 
     let code = answer.error_code().expect("valid error code");
-    assert_eq!(code, APDUErrorCode::NoError);
+    assert_eq!(code, ApduErrorCode::NoError);
 
     assert_eq!(answer.apdu_data(), &APDU_RESPONSE[..4]);
 }
@@ -62,7 +62,7 @@ fn apdu_answer_vec() {
     let answer = APDUAnswer::from_answer(APDU_RESPONSE.to_vec()).expect("valid answer length >= 2");
 
     let code = answer.error_code().expect("valid error code");
-    assert_eq!(code, APDUErrorCode::NoError);
+    assert_eq!(code, ApduErrorCode::NoError);
 
     assert_eq!(answer.apdu_data(), &APDU_RESPONSE[..4]);
 }
@@ -72,7 +72,7 @@ fn apdu_answer_error() {
     let answer = APDUAnswer::from_answer(&[0x64, 0x00][..]).expect("valid answer length >= 2");
 
     let code = answer.error_code().expect("valid error code");
-    assert_eq!(code, APDUErrorCode::ExecutionError);
+    assert_eq!(code, ApduErrorCode::ExecutionError);
 
     assert_eq!(answer.apdu_data(), &[]);
 }

--- a/ledger-transport-hid/Cargo.toml
+++ b/ledger-transport-hid/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "*"
 ledger-transport = "0.10"
 ledger-apdu = "0.10.0"
 
-hidapi = { version = "1.4.1", features = ["linux-static-hidraw"], default-features = false }
+hidapi = { version = "2.2.2", features = ["linux-static-hidraw"], default-features = false }
 
 [dev-dependencies]
 once_cell = "1"

--- a/ledger-transport-hid/Cargo.toml
+++ b/ledger-transport-hid/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 async-trait = "*"
 
 ledger-transport = "0.10"
-ledger-apdu = "*"
+ledger-apdu = "0.10.0"
 
 hidapi = { version = "1.4.1", features = ["linux-static-hidraw"], default-features = false }
 

--- a/ledger-transport-hid/Cargo.toml
+++ b/ledger-transport-hid/Cargo.toml
@@ -18,8 +18,10 @@ cfg-if = "1.0.0"
 thiserror = "1.0"
 hex = "0.4"
 log = "0.4"
+async-trait = "*"
 
 ledger-transport = "0.10"
+ledger-apdu = "*"
 
 hidapi = { version = "1.4.1", features = ["linux-static-hidraw"], default-features = false }
 

--- a/ledger-transport-hid/src/errors.rs
+++ b/ledger-transport-hid/src/errors.rs
@@ -32,4 +32,6 @@ pub enum LedgerHIDError {
     /// UT8F error
     #[error("Ledger device: UTF8 error")]
     UTF8(#[from] std::str::Utf8Error),
+    #[error("APDU error {0}")]
+    Apdu(#[from] ledger_apdu::ApduError),
 }

--- a/ledger-transport-hid/src/lib.rs
+++ b/ledger-transport-hid/src/lib.rs
@@ -345,8 +345,8 @@ mod integration_tests {
 
         // use device info command that works in the dashboard
         let (r1, r2) = futures::executor::block_on(futures::future::join(
-            Dummy::get_device_info(&t1, &mut buff),
-            Dummy::get_device_info(&t2, &mut buff),
+            Dummy::get_device_info(&t1, &mut buff[..]),
+            Dummy::get_device_info(&t2, &mut buff[..]),
         ));
 
         let (r1, r2) = (

--- a/ledger-transport-hid/src/lib.rs
+++ b/ledger-transport-hid/src/lib.rs
@@ -331,7 +331,8 @@ mod integration_tests {
             const CLA: u8 = 0;
         }
 
-        let mut buff = [0u8; 256];
+        let mut buff0 = [0u8; 256];
+        let mut buff1 = [0u8; 256];
 
         init_logging();
 
@@ -345,8 +346,8 @@ mod integration_tests {
 
         // use device info command that works in the dashboard
         let (r1, r2) = futures::executor::block_on(futures::future::join(
-            Dummy::get_device_info(&t1, &mut buff[..]),
-            Dummy::get_device_info(&t2, &mut buff[..]),
+            Dummy::get_device_info(&t1, &mut buff0[..]),
+            Dummy::get_device_info(&t2, &mut buff1[..]),
         ));
 
         let (r1, r2) = (

--- a/ledger-transport-hid/src/lib.rs
+++ b/ledger-transport-hid/src/lib.rs
@@ -16,11 +16,11 @@
 mod errors;
 pub use errors::LedgerHIDError;
 
-use byteorder::{BigEndian, ByteOrder, ReadBytesExt, NetworkEndian};
+use byteorder::{BigEndian, ReadBytesExt};
 use hidapi::{DeviceInfo, HidApi, HidDevice};
-use log::{info, debug};
+use log::{debug};
 
-use std::{io::Cursor, ops::Deref, sync::Mutex};
+use std::{io::Cursor, sync::Mutex};
 
 pub use hidapi;
 

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.56"
 byteorder = "1.4.3"
 
 ledger-transport = "0.10"
-tokio = { version = "1.20.1", features = [ "net", "time" ] }
+tokio = { version = "1.20.1", features = [ "net", "time", "sync", "io-util" ] }
 
 clap = { version = "3.2.15", features = [ "derive", "env" ], optional = true }
 

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1.56"
 byteorder = "1.4.3"
 
 ledger-transport = "0.10"
+ledger-apdu = "0.10"
 tokio = { version = "1.20.1", features = [ "net", "time", "sync", "io-util" ] }
 
 clap = { version = "3.2.15", features = [ "derive", "env" ], optional = true }

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -12,16 +12,13 @@ keywords = ["ledger", "nano", "blue", "apdu", "tcp"]
 edition = "2021"
 
 [features]
-default = [ "clap" ]
+default = []
 
 [dependencies]
 thiserror = "1.0"
 log = "0.4"
 async-trait = "0.1.56"
-
 byteorder = "1.4.3"
-
-humantime = "2.1.0"
 
 ledger-transport = "0.10"
 tokio = { version = "1.20.1", features = [ "net", "time" ] }

--- a/ledger-transport-tcp/Cargo.toml
+++ b/ledger-transport-tcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ledger-transport-tcp"
+description = "Ledger Hardware Wallet - TCP (Speculos) Transport"
+version = "0.10.0"
+license = "Apache-2.0"
+authors = ["Linfeng Yuan <linfeng@crypto.com>"]
+homepage = "https://github.com/zondax/ledger-rs"
+repository = "https://github.com/zondax/ledger-rs"
+readme = "README.md"
+categories  = ["authentication", "cryptography"]
+keywords = ["ledger", "nano", "blue", "apdu", "tcp"]
+edition = "2021"
+
+[features]
+default = [ "clap" ]
+
+[dependencies]
+thiserror = "1.0"
+log = "0.4"
+async-trait = "0.1.56"
+
+byteorder = "1.4.3"
+
+humantime = "2.1.0"
+
+ledger-transport = "0.10"
+tokio = { version = "1.20.1", features = [ "net", "time" ] }
+
+clap = { version = "3.2.15", features = [ "derive", "env" ], optional = true }
+

--- a/ledger-transport-tcp/src/error.rs
+++ b/ledger-transport-tcp/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
 
     #[error("Invalid answer APDU")]
     InvalidAnswer,
+
+    #[error("APDU Error")]
+    ApduError,
 }
 
 impl From<std::io::Error> for Error {
@@ -23,5 +26,11 @@ impl From<std::io::Error> for Error {
 impl From<tokio::time::error::Elapsed> for Error {
     fn from(_: tokio::time::error::Elapsed) -> Self {
         Error::Timeout
+    }
+}
+
+impl From<ledger_apdu::ApduError> for Error {
+    fn from(_: ledger_apdu::ApduError) -> Self {
+        Self::ApduError
     }
 }

--- a/ledger-transport-tcp/src/error.rs
+++ b/ledger-transport-tcp/src/error.rs
@@ -4,9 +4,6 @@ pub enum Error {
     #[error("IO error {:?}", 0)]
     Io(std::io::Error),
 
-    #[error("Connection failed: {:?}", 0)]
-    Connection(std::io::Error),
-
     #[error("Command timeout")]
     Timeout,
 

--- a/ledger-transport-tcp/src/error.rs
+++ b/ledger-transport-tcp/src/error.rs
@@ -1,0 +1,30 @@
+/// Speculos (TCP) transport errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("IO error {:?}", 0)]
+    Io(std::io::Error),
+
+    #[error("Connection failed: {:?}", 0)]
+    Connection(std::io::Error),
+
+    #[error("Command timeout")]
+    Timeout,
+
+    #[error("Invalid response length")]
+    InvalidLength,
+
+    #[error("Invalid answer APDU")]
+    InvalidAnswer,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        Error::Timeout
+    }
+}

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -93,9 +93,8 @@ impl Exchange for TransportTcp {
         let mut tx_len = Self::apdu_encode(&command, &mut buff[4..])?;
 
         // Write message length prefix
-        NetworkEndian::write_u32(&mut buff[..4], 4 + tx_len as u32);
+        NetworkEndian::write_u32(&mut buff[..4], tx_len as u32);
         tx_len += 4;
-
 
         log::debug!("Sending command: {:02x?} ({})", &buff[..tx_len], tx_len);
 
@@ -107,7 +106,7 @@ impl Exchange for TransportTcp {
         // Await response
         log::debug!("Awaiting response...");
 
-        // Read length header
+        // Read length prefix
         let rx_len = match tokio::time::timeout(self.timeout, s.read(&mut buff[..4])).await?? {
             // Length header + status bytes
             4 => NetworkEndian::read_u32(&buff[..4]) as usize + 2,

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -1,0 +1,118 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    ops::Deref,
+    time::Duration,
+};
+
+use byteorder::{ByteOrder, NetworkEndian};
+use ledger_transport::{APDUAnswer, APDUCommand, Exchange};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    sync::Mutex,
+};
+
+mod error;
+pub use error::Error;
+
+/// Ledger speculos (TCP) transport
+pub struct TransportTcp {
+    s: Mutex<TcpStream>,
+    timeout: Duration,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+pub struct TcpOptions {
+    /// IP Address for TCP connection
+    #[cfg_attr(feature = "clap", clap(long, default_value = "127.0.0.1", env))]
+    pub addr: IpAddr,
+
+    /// Port for TCP connection
+    #[cfg_attr(feature = "clap", clap(long, default_value = "1237", env))]
+    pub port: u16,
+
+    /// Request/Response timeout
+    #[cfg_attr(feature = "clap", clap(long, default_value = "3s", env))]
+    pub timeout: humantime::Duration,
+}
+
+impl TransportTcp {
+    /// Create a new speculos (TCP) transport
+    pub async fn new(o: TcpOptions) -> Result<Self, Error> {
+        let addr = SocketAddr::new(o.addr, o.port);
+
+        log::debug!("Using socket: {}", addr);
+
+        let s = match TcpStream::connect(addr).await {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("Failed to connect to TCP socket: {}", addr);
+                return Err(Error::Connection(e));
+            }
+        };
+
+        log::debug!("Socket bound ({:?})", s.local_addr());
+
+        Ok(Self {
+            s: Mutex::new(s),
+            timeout: *o.timeout,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Exchange for TransportTcp {
+    type Error = Error;
+    type AnswerType = Vec<u8>;
+
+    async fn exchange<I>(
+        &self,
+        command: &APDUCommand<I>,
+    ) -> Result<APDUAnswer<Self::AnswerType>, Self::Error>
+    where
+        I: Deref<Target = [u8]> + Send + Sync,
+    {
+        let mut s = self.s.lock().await;
+
+        // Encode command object
+        let out = command.serialize();
+
+        let mut buff = vec![0u8; out.len() + 4];
+        NetworkEndian::write_u32(&mut buff, out.len() as u32);
+        buff[4..].copy_from_slice(&out);
+
+        log::debug!("Sending command: {:02x?} ({})", out, out.len());
+
+        // Send command
+        s.write(&buff).await?;
+
+        // Await response
+        let mut buff = [0u8; 4];
+
+        log::debug!("Awaiting response...");
+
+        // Read length header
+        let len = match tokio::time::timeout(self.timeout, s.read(&mut buff)).await?? {
+            4 => NetworkEndian::read_u32(&buff[..4]),
+            _ => return Err(Error::InvalidLength),
+        };
+
+        log::debug!("Expected {} byte response", len);
+
+        // Read response body
+        let mut buff = vec![0u8; len as usize + 2];
+        tokio::time::timeout(self.timeout, s.read_exact(&mut buff)).await??;
+
+        log::debug!("Received answer: {:02x?} ({})", buff, len);
+
+        // Decode answer ADPU
+        let answer = APDUAnswer::from_answer(buff).map_err(|_| Error::InvalidAnswer)?;
+
+        log::debug!("Decoded APDU: {:02x?}", answer);
+
+        // Return ADPU
+        Ok(answer)
+    }
+}

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -112,12 +112,12 @@ impl Exchange for TransportTcp {
 
         // Read length header
         let rx_len = match tokio::time::timeout(self.timeout, s.read(&mut buff[..4])).await?? {
-            4 => NetworkEndian::read_u32(&buff[..4]) as usize,
+            /// Length header + status bytes
+            4 => NetworkEndian::read_u32(&buff[..4]) as usize + 2,
             _ => return Err(Error::InvalidLength),
         };
 
         log::debug!("Expected {} byte response", rx_len);
-
 
         // Read response body
         tokio::time::timeout(self.timeout, s.read_exact(&mut buff[..rx_len])).await??;

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -93,12 +93,12 @@ impl Exchange for TransportTcp {
         let tx_len = command.encode(&mut buff[ADPU_HDR_LEN..]);
 
         // Write header
-        NetworkEndian::write_u32(&mut buff[..4], tx_len as u32);
-        buff[5] = CMD::CLA;
-        buff[6] = CMD::INS;
-        buff[7] = command.p1();
-        buff[8] = command.p2();
-        buff[9] = tx_len as u8 + 2;
+        NetworkEndian::write_u32(&mut buff[..4], tx_len as u32 + 5);
+        buff[4] = CMD::CLA;
+        buff[5] = CMD::INS;
+        buff[6] = command.p1();
+        buff[7] = command.p2();
+        buff[8] = tx_len as u8;
 
         log::debug!("Sending command: {:02x?} ({})", &buff[..tx_len + ADPU_HDR_LEN], tx_len);
 
@@ -122,7 +122,7 @@ impl Exchange for TransportTcp {
         // Read response body
         tokio::time::timeout(self.timeout, s.read_exact(&mut buff[..rx_len])).await??;
 
-        log::debug!("Received answer: {:02x?} ({})", buff, rx_len);
+        log::debug!("Received answer: {:02x?} ({})", &buff[..rx_len], rx_len);
 
         // Decode answer ADPU
         let answer = ANS::decode(&buff[..rx_len])

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use byteorder::{ByteOrder, NetworkEndian};
-use ledger_transport::{Exchange, ApduCmd, ApduBase, ApduHeader};
+use ledger_transport::{Exchange, ApduCmd, ApduBase};
 
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -74,8 +74,6 @@ impl TransportTcp {
         })
     }
 }
-
-const APDU_HDR_LEN: usize = 4 + 5;
 
 #[async_trait::async_trait]
 impl Exchange for TransportTcp {

--- a/ledger-transport-tcp/src/lib.rs
+++ b/ledger-transport-tcp/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::Deref,
     time::Duration,
 };
@@ -16,26 +16,38 @@ use tokio::{
 mod error;
 pub use error::Error;
 
-/// Ledger speculos (TCP) transport
+/// Ledger TCP (speculos) ADPU transport
 pub struct TransportTcp {
     s: Mutex<TcpStream>,
     timeout: Duration,
 }
 
+/// Configuration options for [`TransportTcp`]
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct TcpOptions {
-    /// IP Address for TCP connection
-    #[cfg_attr(feature = "clap", clap(long, default_value = "127.0.0.1", env))]
+    /// TCP address for ADPU connection
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = TcpOptions::default().addr, env = "TCP_ADDR"))]
     pub addr: IpAddr,
 
-    /// Port for TCP connection
-    #[cfg_attr(feature = "clap", clap(long, default_value = "1237", env))]
+    /// TCP port for ADPU connection
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = TcpOptions::default().port, env = "TCP_PORT"))]
     pub port: u16,
 
-    /// Request/Response timeout
-    #[cfg_attr(feature = "clap", clap(long, default_value = "3s", env))]
-    pub timeout: humantime::Duration,
+    /// ADPU timeout in milliseconds
+    #[cfg_attr(feature = "clap", clap(default_value_t = TcpOptions::default().timeout_ms, env = "TCP_TIMEOUT_MS"))]
+    pub timeout_ms: u64,
+}
+
+/// Default configuration for [`TransportTcp`]
+impl Default for TcpOptions {
+    fn default() -> Self {
+        Self {
+            addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            port: 1237,
+            timeout_ms: 3000,
+        }
+    }
 }
 
 impl TransportTcp {
@@ -45,19 +57,21 @@ impl TransportTcp {
 
         log::debug!("Using socket: {}", addr);
 
+        // Bind TCP connection
         let s = match TcpStream::connect(addr).await {
             Ok(s) => s,
             Err(e) => {
                 log::warn!("Failed to connect to TCP socket: {}", addr);
-                return Err(Error::Connection(e));
+                return Err(Error::Io(e));
             }
         };
 
         log::debug!("Socket bound ({:?})", s.local_addr());
 
+        // Build object
         Ok(Self {
             s: Mutex::new(s),
-            timeout: *o.timeout,
+            timeout: Duration::from_millis(o.timeout_ms),
         })
     }
 }
@@ -67,6 +81,7 @@ impl Exchange for TransportTcp {
     type Error = Error;
     type AnswerType = Vec<u8>;
 
+    /// Exchange an ADPU with via the TCP transport
     async fn exchange<I>(
         &self,
         command: &APDUCommand<I>,

--- a/ledger-transport/Cargo.toml
+++ b/ledger-transport/Cargo.toml
@@ -13,5 +13,6 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-
+byteorder = { version = "*", default_features = false }
+encdec = "0.6.1"
 ledger-apdu = "0.10.0"

--- a/ledger-transport/src/lib.rs
+++ b/ledger-transport/src/lib.rs
@@ -84,3 +84,16 @@ pub trait Exchange: Send {
     }
 
 }
+
+#[async_trait]
+impl <T: Exchange + Send + Sync> Exchange for &T {
+    type Error = <T as Exchange>::Error;
+
+    async fn exchange<'a, 'c, ANS: ApduBase<'a>>(
+        &self,
+        command: impl ApduCmd<'c>,
+        buff: &'a mut [u8],
+    ) -> Result<ANS, Self::Error> {
+        <T as Exchange>::exchange(self, command, buff).await
+    }
+}

--- a/ledger-zondax-generic/Cargo.toml
+++ b/ledger-zondax-generic/Cargo.toml
@@ -16,4 +16,5 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 ledger-transport = "0.10"
+ledger-apdu = "0.10"
 async-trait = "0.1"

--- a/ledger-zondax-generic/src/lib.rs
+++ b/ledger-zondax-generic/src/lib.rs
@@ -28,13 +28,8 @@ use serde::{Deserialize, Serialize};
 use std::str;
 
 use async_trait::async_trait;
-use ledger_transport::{APDUAnswer, APDUCommand, APDUErrorCode, Exchange};
+use ledger_transport::{APDUErrorCode, Exchange};
 
-const INS_GET_VERSION: u8 = 0x00;
-const CLA_APP_INFO: u8 = 0xb0;
-const INS_APP_INFO: u8 = 0x01;
-const CLA_DEVICE_INFO: u8 = 0xe0;
-const INS_DEVICE_INFO: u8 = 0x01;
 const USER_MESSAGE_CHUNK_SIZE: usize = 250;
 
 /// Chunk payload type

--- a/ledger-zondax-generic/src/lib.rs
+++ b/ledger-zondax-generic/src/lib.rs
@@ -24,13 +24,22 @@
 mod errors;
 pub use errors::*;
 
-use serde::{Deserialize, Serialize};
-use std::str;
-
 use async_trait::async_trait;
-use ledger_transport::{APDUErrorCode, Exchange};
 
-const USER_MESSAGE_CHUNK_SIZE: usize = 250;
+use ledger_apdu::{
+    apdus::{
+        DeviceInfo, DeviceInfoGet,
+        AppInfo, AppInfoGet,
+        Generic, Empty,
+    }, ApduCmd, ApduBase,
+};
+use ledger_transport::Exchange;
+
+/// Maximum size of a user message
+pub const USER_MESSAGE_CHUNK_SIZE: usize = 250;
+
+/// Maximum size of an encode APDU (based on u8 len field)
+pub const APDU_LEN_MAX: usize = 256;
 
 /// Chunk payload type
 pub enum ChunkPayloadType {
@@ -42,72 +51,9 @@ pub enum ChunkPayloadType {
     Last = 0x02,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-/// App Version
-pub struct Version {
-    /// Application Mode
-    #[serde(rename(serialize = "testMode"))]
-    pub mode: u8,
-    /// Version Major
-    pub major: u16,
-    /// Version Minor
-    pub minor: u16,
-    /// Version Patch
-    pub patch: u16,
-    /// Device is locked
-    pub locked: bool,
-    /// Target ID
-    pub target_id: [u8; 4],
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-/// App Information
-pub struct AppInfo {
-    /// Name of the application
-    #[serde(rename(serialize = "appName"))]
-    pub app_name: String,
-    /// App version
-    #[serde(rename(serialize = "appVersion"))]
-    pub app_version: String,
-    /// Flag length
-    #[serde(rename(serialize = "flagLen"))]
-    pub flag_len: u8,
-    /// Flag value
-    #[serde(rename(serialize = "flagsValue"))]
-    pub flags_value: u8,
-    /// Flag Recovery
-    #[serde(rename(serialize = "flagsRecovery"))]
-    pub flag_recovery: bool,
-    /// Flag Signed MCU code
-    #[serde(rename(serialize = "flagsSignedMCUCode"))]
-    pub flag_signed_mcu_code: bool,
-    /// Flag Onboarded
-    #[serde(rename(serialize = "flagsOnboarded"))]
-    pub flag_onboarded: bool,
-    /// Flag Pin Validated
-    #[serde(rename(serialize = "flagsPINValidated"))]
-    pub flag_pin_validated: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-/// App Device Info
-pub struct DeviceInfo {
-    /// Target ID
-    #[serde(rename(serialize = "targetId"))]
-    pub target_id: [u8; 4],
-    /// Secure Element Version
-    #[serde(rename(serialize = "seVersion"))]
-    pub se_version: String,
-    /// Device Flag
-    pub flag: Vec<u8>,
-    /// MCU Version
-    #[serde(rename(serialize = "mcuVersion"))]
-    pub mcu_version: String,
-}
-
-/// Defines what we can consider an "App"
+/// Defines what we can consider an "App" with a specified "CLA"
 pub trait App {
-    /// App's APDU CLA
+    /// Application APDU class
     const CLA: u8;
 }
 
@@ -115,244 +61,42 @@ pub trait App {
 /// Common commands for any given APP
 ///
 /// This trait is automatically implemented for any type that implements [App]
-pub trait AppExt<E>: App
+pub trait AppExt<E>
 where
     E: Exchange + Send + Sync,
     E::Error: std::error::Error,
 {
     /// Retrieve the device info
     ///
-    /// Works only in the dashboard
-    async fn get_device_info(transport: &E) -> Result<DeviceInfo, LedgerAppError<E::Error>> {
-        let command = APDUCommand {
-            cla: CLA_DEVICE_INFO,
-            ins: INS_DEVICE_INFO,
-            p1: 0x00,
-            p2: 0x00,
-            data: Vec::new(),
-        };
-
-        let response = transport.exchange(&command).await?;
-        match response.error_code() {
-            Ok(APDUErrorCode::NoError) => {}
-            Ok(err) => return Err(LedgerAppError::Unknown(err as _)),
-            Err(err) => return Err(LedgerAppError::Unknown(err)),
-        }
-
-        let response_data = response.data();
-
-        let target_id_slice = &response_data[0..4];
-        let mut idx = 4;
-        let se_version_len: usize = response_data[idx] as usize;
-        idx += 1;
-        let se_version_bytes = &response_data[idx..idx + se_version_len];
-
-        idx += se_version_len;
-
-        let flags_len: usize = response_data[idx] as usize;
-        idx += 1;
-        let flag = &response_data[idx..idx + flags_len];
-        idx += flags_len;
-
-        let mcu_version_len: usize = response_data[idx] as usize;
-        idx += 1;
-        let mut tmp = &response_data[idx..idx + mcu_version_len];
-        if tmp[mcu_version_len - 1] == 0 {
-            tmp = &response_data[idx..idx + mcu_version_len - 1];
-        }
-
-        let mut target_id = [Default::default(); 4];
-        target_id.copy_from_slice(target_id_slice);
-
-        let se_version = str::from_utf8(se_version_bytes).map_err(|_e| LedgerAppError::Utf8)?;
-        let mcu_version = str::from_utf8(tmp).map_err(|_e| LedgerAppError::Utf8)?;
-
-        let device_info = DeviceInfo {
-            target_id,
-            se_version: se_version.to_string(),
-            flag: flag.to_vec(),
-            mcu_version: mcu_version.to_string(),
-        };
-
-        Ok(device_info)
+    /// Works only when the device is on the dashboard
+    async fn get_device_info<'a>(transport: &E, buff: &'a mut[u8]) -> Result<DeviceInfo<'a>, LedgerAppError<E::Error>> {
+        transport.exchange::<DeviceInfo>(DeviceInfoGet{}, buff).await
+            .map_err(LedgerAppError::TransportError)
     }
 
     /// Retrieve the app info
     ///
-    /// Works only in app (TOOD: dashboard support)
-    async fn get_app_info(transport: &E) -> Result<AppInfo, LedgerAppError<E::Error>> {
-        let command = APDUCommand {
-            cla: CLA_APP_INFO,
-            ins: INS_APP_INFO,
-            p1: 0x00,
-            p2: 0x00,
-            data: Vec::new(),
-        };
-
-        let response = transport.exchange(&command).await?;
-        match response.error_code() {
-            Ok(APDUErrorCode::NoError) => {}
-            Ok(err) => return Err(LedgerAppError::AppSpecific(err as _, err.description())),
-            Err(err) => return Err(LedgerAppError::Unknown(err as _)),
-        }
-
-        let response_data = response.data();
-
-        if response_data[0] != 1 {
-            return Err(LedgerAppError::InvalidFormatID);
-        }
-
-        let app_name_len: usize = response_data[1] as usize;
-        let app_name_bytes = &response_data[2..app_name_len];
-
-        let mut idx = 2 + app_name_len;
-        let app_version_len: usize = response_data[idx] as usize;
-        idx += 1;
-        let app_version_bytes = &response_data[idx..idx + app_version_len];
-
-        idx += app_version_len;
-
-        let app_flags_len = response_data[idx];
-        idx += 1;
-        let flags_value = response_data[idx];
-
-        let app_name = str::from_utf8(app_name_bytes).map_err(|_e| LedgerAppError::Utf8)?;
-        let app_version = str::from_utf8(app_version_bytes).map_err(|_e| LedgerAppError::Utf8)?;
-
-        let app_info = AppInfo {
-            app_name: app_name.to_string(),
-            app_version: app_version.to_string(),
-            flag_len: app_flags_len,
-            flags_value,
-            flag_recovery: (flags_value & 1) != 0,
-            flag_signed_mcu_code: (flags_value & 2) != 0,
-            flag_onboarded: (flags_value & 4) != 0,
-            flag_pin_validated: (flags_value & 128) != 0,
-        };
-
-        Ok(app_info)
+    /// Works only in app (TODO: dashboard support)
+    async fn get_app_info<'a>(transport: &E, buff: &'a mut[u8]) -> Result<AppInfo<'a>, LedgerAppError<E::Error>> {
+        transport.exchange::<AppInfo>(AppInfoGet{}, buff).await
+            .map_err(LedgerAppError::TransportError)
     }
 
     /// Retrieve the app version
-    async fn get_version(transport: &E) -> Result<Version, LedgerAppError<E::Error>> {
-        let command = APDUCommand {
-            cla: Self::CLA,
-            ins: INS_GET_VERSION,
-            p1: 0x00,
-            p2: 0x00,
-            data: Vec::new(),
-        };
-
-        let response = transport.exchange(&command).await?;
-        match response.error_code() {
-            Ok(APDUErrorCode::NoError) => {}
-            Ok(err) => return Err(LedgerAppError::Unknown(err as _)),
-            Err(err) => return Err(LedgerAppError::Unknown(err)),
-        }
-
-        let response_data = response.data();
-
-        let version = match response_data.len() {
-            // single byte version numbers
-            4 => Version {
-                mode: response_data[0],
-                major: response_data[1] as u16,
-                minor: response_data[2] as u16,
-                patch: response_data[3] as u16,
-                locked: false,
-                target_id: [0, 0, 0, 0],
-            },
-            // double byte version numbers
-            7 => Version {
-                mode: response_data[0],
-                major: response_data[1] as u16 * 256 + response_data[2] as u16,
-                minor: response_data[3] as u16 * 256 + response_data[4] as u16,
-                patch: response_data[5] as u16 * 256 + response_data[6] as u16,
-                locked: false,
-                target_id: [0, 0, 0, 0],
-            },
-            // double byte version numbers + lock + target id
-            9 => Version {
-                mode: response_data[0],
-                major: response_data[1] as u16,
-                minor: response_data[2] as u16,
-                patch: response_data[3] as u16,
-                locked: response_data[4] != 0,
-                target_id: [
-                    response_data[5],
-                    response_data[6],
-                    response_data[7],
-                    response_data[8],
-                ],
-            },
-            // double byte version numbers + lock + target id
-            12 => Version {
-                mode: response_data[0],
-                major: response_data[1] as u16 * 256 + response_data[2] as u16,
-                minor: response_data[3] as u16 * 256 + response_data[4] as u16,
-                patch: response_data[5] as u16 * 256 + response_data[6] as u16,
-                locked: response_data[7] != 0,
-                target_id: [
-                    response_data[8],
-                    response_data[9],
-                    response_data[10],
-                    response_data[11],
-                ],
-            },
-            _ => return Err(LedgerAppError::InvalidVersion),
-        };
-        Ok(version)
+    #[cfg(nyet)]
+    async fn get_version<'a>(transport: &E, buff: &'a mut[u8]) -> Result<Version, LedgerAppError<E::Error>> {
+        transport.exchange::<Version>(VersionGet{cla: Self::CLA}, buff).await
+            .map_err(LedgerAppError::TransportError)
     }
 
     /// Stream a long request in chunks
-    async fn send_chunks<I: std::ops::Deref<Target = [u8]> + Send + Sync>(
-        transport: &E,
-        command: APDUCommand<I>,
+    async fn send_chunks<'a, 'c, ANS: ApduBase<'a>>(
+        transport: impl Exchange<Error=E::Error> + Sync,
+        command: impl ApduCmd<'c>,
         message: &[u8],
-    ) -> Result<APDUAnswer<E::AnswerType>, LedgerAppError<E::Error>> {
-        let chunks = message.chunks(USER_MESSAGE_CHUNK_SIZE);
-        match chunks.len() {
-            0 => return Err(LedgerAppError::InvalidEmptyMessage),
-            n if n > 255 => return Err(LedgerAppError::InvalidMessageSize),
-            _ => (),
-        }
-
-        if command.p1 != ChunkPayloadType::Init as u8 {
-            return Err(LedgerAppError::InvalidChunkPayloadType);
-        }
-
-        let mut response = transport.exchange(&command).await?;
-        match response.error_code() {
-            Ok(APDUErrorCode::NoError) => {}
-            Ok(err) => return Err(LedgerAppError::AppSpecific(err as _, err.description())),
-            Err(err) => return Err(LedgerAppError::Unknown(err as _)),
-        }
-
-        // Send message chunks
-        let last_chunk_index = chunks.len() - 1;
-        for (packet_idx, chunk) in chunks.enumerate() {
-            let mut p1 = ChunkPayloadType::Add as u8;
-            if packet_idx == last_chunk_index {
-                p1 = ChunkPayloadType::Last as u8
-            }
-
-            let command = APDUCommand {
-                cla: command.cla,
-                ins: command.ins,
-                p1,
-                p2: 0,
-                data: chunk.to_vec(),
-            };
-
-            response = transport.exchange(&command).await?;
-            match response.error_code() {
-                Ok(APDUErrorCode::NoError) => {}
-                Ok(err) => return Err(LedgerAppError::AppSpecific(err as _, err.description())),
-                Err(err) => return Err(LedgerAppError::Unknown(err as _)),
-            }
-        }
-
-        Ok(response)
+        buff: &'a mut [u8],
+    ) -> Result<ANS, LedgerAppError<E::Error>> {
+        send_chunks_inner::<ANS, _>(transport, command, message, buff).await
     }
 }
 
@@ -362,4 +106,65 @@ where
     E: Exchange + Send + Sync,
     E::Error: std::error::Error,
 {
+}
+
+
+/// Stream a long request in chunks
+// TODO: we can't adapt between const generics -yet- so this type signature is a little more gnarley than would be ideal... should improve in the next month or so
+
+async fn send_chunks_inner<'a, 'c, ANS, ERR>(
+    transport: impl Exchange<Error=ERR>,
+    command: impl ApduCmd<'c>,
+    message: &[u8],
+    buff: &'a mut [u8],
+) -> Result<ANS, LedgerAppError<ERR>> 
+where
+    ANS: ApduBase<'a>,
+    ERR: std::error::Error,
+{
+    let mut b = [0u8; APDU_LEN_MAX];
+
+    // Compute chunks for streaming
+    let chunks = message.chunks(USER_MESSAGE_CHUNK_SIZE);
+    match chunks.len() {
+        0 => return Err(LedgerAppError::InvalidEmptyMessage),
+        n if n > 255 => return Err(LedgerAppError::InvalidMessageSize),
+        _ => (),
+    }
+
+    let hdr = command.header();
+    if hdr.p1 != ChunkPayloadType::Init as u8 {
+        return Err(LedgerAppError::InvalidChunkPayloadType);
+    }
+
+
+    // Write first / init command
+    transport.exchange::<Empty>(command, &mut b[..]).await
+        .map_err(LedgerAppError::TransportError)?;
+
+
+    // Send message chunks
+    let last_chunk_index = chunks.len() - 1;
+    for (packet_idx, chunk) in chunks.enumerate() {
+
+        let mut p1 = ChunkPayloadType::Add as u8;
+        if packet_idx == last_chunk_index {
+            p1 = ChunkPayloadType::Last as u8
+        }
+
+        let command = Generic::new(hdr.cla, hdr.ins, p1, 0, chunk);
+
+        // Parse answer to final packet
+        if packet_idx < last_chunk_index {
+            let _ = transport.exchange::<Empty>(command, &mut b[..]).await
+                .map_err(LedgerAppError::TransportError)?;
+        } else {
+            let response = transport.exchange::<ANS>(command, &mut buff[..]).await
+                .map_err(LedgerAppError::TransportError)?;
+            
+            return Ok(response);
+        }
+    }
+
+    unreachable!()
 }


### PR DESCRIPTION
howdy, we're working on a ledger app and hoping to share as much as possible between the firmware / interface library and command line tooling.

to that end this is an alternate approach to the way `APDU`s are defined which allows these to be shared, supporting higher-level type safe interfaces while allowing you to use the same APDU definitions (without `std` or `alloc`) on the ledger:

```rust
fn handle_apdu(comm: &mut io::Comm) -> Result<(), Reply> {
    let (cla, ins) = comm.get_cla_ins();

    match ins {
        apdu::AppInfoGet::INS => {
            if let Ok(req) = apdu::AppInfoGet::decode(&comm.apdu_buffer) {
                let i = apdu::AppInfo::new(NAME, VERSION, apdu::AppFlags::empty());
                let n = i.encode(&mut comm.apdu_buffer);

                comm.tx = n;
                comm.reply_ok();
            } else {
                comm.reply(SyscallError::InvalidParameter);
            }
        },
        ...
    }
}
```

this does require you to explicitly pass buffers, but the corollary is that you can read/write using existing buffers instead of allocating which is quite neat for larger objects. and is very much a WIP, i have updated the `ledger-apdu` package with new traits and definitions, and `ledger-transport` / `ledger-transport-tcp` to show how they're used (though not yet propagated the return codes), but i wanted to see what y'all think of this approach before committing more effort?

<!-- ClickUpRef: 2ua03ek -->
:link: [zboto Link](https://app.clickup.com/t/2ua03ek)