### PR TITLE
feat: add speculos transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ledger-transport",
     "ledger-transport-hid",
     "ledger-transport-zemu",
+    "ledger-transport-speculos",
     "ledger-zondax-generic",
 ]
 
@@ -20,4 +21,5 @@ ledger-apdu = { path = "ledger-apdu" }
 ledger-transport = { path = "ledger-transport" }
 ledger-transport-hid = { path = "ledger-transport-hid" }
 ledger-transport-zemu = { path = "ledger-transport-zemu" }
+ledger-transport-speculos = { path = "ledger-transport-speculos" }
 ledger-zondax-generic = { path = "ledger-zondax-generic" }

--- a/ledger-transport-speculos/.gitignore
+++ b/ledger-transport-speculos/.gitignore
@@ -1,0 +1,2 @@
+zemu.rs
+zemu_grpc.rs

--- a/ledger-transport-speculos/Cargo.toml
+++ b/ledger-transport-speculos/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ledger-transport-speculos"
+description = "Ledger Hardware Wallet - Speculos Transport"
+version = "0.10.0"
+license = "Apache-2.0"
+authors = ["Linfeng Yuan <linfeng@crypto.com>", "Trevor Arjeski <tmarjeski@gmail.com"]
+homepage = "https://github.com/zondax/ledger-rs"
+repository = "https://github.com/zondax/ledger-rs"
+readme = "README.md"
+categories  = ["authentication", "cryptography"]
+keywords = ["ledger", "nano", "blue", "apdu", "zemu"]
+edition = "2021"
+
+[dependencies]
+thiserror = "1.0"
+log = "0.4"
+reqwest = { version = "0.11", features = ["json"]}
+hex = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+
+ledger-transport = "0.10"

--- a/ledger-transport-speculos/README.md
+++ b/ledger-transport-speculos/README.md
@@ -1,0 +1,5 @@
+# ledger-transport-speculos
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+Ledger APDU transport - Speculos backend

--- a/ledger-transport-speculos/src/errors.rs
+++ b/ledger-transport-speculos/src/errors.rs
@@ -1,0 +1,29 @@
+/*******************************************************************************
+*   (c) 2022 Zondax AG
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LedgerSpeculosError {
+    /// Device not found error
+    #[error("Ledger connect error")]
+    ConnectError,
+    /// speculos reponse error
+    #[error("Speculos response error")]
+    ResponseError,
+    /// Inner error
+    #[error("Ledger inner error")]
+    InnerError,
+}

--- a/ledger-transport-speculos/src/errors.rs
+++ b/ledger-transport-speculos/src/errors.rs
@@ -21,8 +21,8 @@ pub enum LedgerSpeculosError {
     #[error("Ledger connect error")]
     ConnectError,
     /// speculos reponse error
-    #[error("Speculos response error")]
-    ResponseError,
+    #[error("Speculos response error: {0}")]
+    ResponseError(String),
     /// Inner error
     #[error("Ledger inner error")]
     InnerError,

--- a/ledger-transport-speculos/src/lib.rs
+++ b/ledger-transport-speculos/src/lib.rs
@@ -1,0 +1,100 @@
+/*******************************************************************************
+*   (c) 2022 Zondax AG
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
+use reqwest::{Client as HttpClient, Response};
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+use std::time::Duration;
+
+use ledger_transport::{async_trait, APDUAnswer, APDUCommand, Exchange};
+
+mod errors;
+pub use errors::LedgerSpeculosError;
+
+pub struct TransportSpeculosHttp {
+    url: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct SpeculosRequest {
+    data: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct SpeculosResponse {
+    data: String,
+    error: Option<String>,
+}
+
+impl TransportSpeculosHttp {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            url: format!("http://{}:{}/apdu", host, port),
+        }
+    }
+}
+
+#[async_trait]
+impl Exchange for TransportSpeculosHttp {
+    type Error = LedgerSpeculosError;
+    type AnswerType = Vec<u8>;
+
+    async fn exchange<I>(
+        &self,
+        command: &APDUCommand<I>,
+    ) -> Result<APDUAnswer<Self::AnswerType>, Self::Error>
+    where
+        I: Deref<Target = [u8]> + Send + Sync,
+    {
+        let raw_command = hex::encode(command.serialize());
+        let request = SpeculosRequest { data: raw_command };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let resp: Response = HttpClient::new()
+            .post(&self.url)
+            .headers(headers)
+            .timeout(Duration::from_secs(5))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| {
+                log::error!("create http client error: {:?}", e);
+                LedgerSpeculosError::InnerError
+            })?;
+        log::debug!("http response: {:?}", resp);
+
+        if resp.status().is_success() {
+            let result: SpeculosResponse = resp.json().await.map_err(|e| {
+                log::error!("error response: {:?}", e);
+                LedgerSpeculosError::ResponseError
+            })?;
+            if result.error.is_none() {
+                APDUAnswer::from_answer(hex::decode(result.data).expect("decode error"))
+                    .map_err(|_| LedgerSpeculosError::ResponseError)
+            } else {
+                Err(LedgerSpeculosError::ResponseError)
+            }
+        } else {
+            log::error!("error response: {:?}", resp.status());
+            Err(LedgerSpeculosError::ResponseError)
+        }
+    }
+}


### PR DESCRIPTION
There are some small differences between `TransportZemuHttp` and the current implementation of speculos, that are now resolved in a new crate
- `ledger-transport-speculos`. The crate contains a transport by the same convention - `TransportSpeculosHttp`.

<!-- ClickUpRef: 8677eykm9 -->
:link: [zboto Link](https://app.clickup.com/t/8677eykm9)